### PR TITLE
FIX: OpenDSS Parser, PowerFlow Problem

### DIFF
--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -27,16 +27,16 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_
     va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.phase_ids(pm)]
     va_to = [var(pm, n, j, :va, t_bus) for j in PMs.phase_ids(pm)]
 
-    @NLconstraint(pm.model, p_fr ==  g_fr[h]*vm_fr[h]^2 + sum(
-                                        g[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) +
-                                        b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) -
-                                        g[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) -
-                                        b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) )
-    @NLconstraint(pm.model, q_fr == -b_fr[h]*vm_fr[h]^2 - sum(
-                                        b[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) -
-                                        g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) -
-                                        b[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                        g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) )
+    @NLconstraint(pm.model, p_fr ==  (g_fr[h]+g[h,h]) * vm_fr[h]^2 +
+                                    sum( g[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) +
+                                         b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.phase_ids(pm) if i != h) +
+                                    sum(-g[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
+                                        -b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) )
+    @NLconstraint(pm.model, q_fr == -(b_fr[h]+b[h,h]) *vm_fr[h]^2 -
+                                    sum( b[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) -
+                                         g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.phase_ids(pm) if i != h) -
+                                    sum(-b[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
+                                         g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) )
 end
 
 
@@ -56,15 +56,15 @@ function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, h::Int, f_bu
     va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.phase_ids(pm)]
     va_to = [var(pm, n, j, :va, t_bus) for j in PMs.phase_ids(pm)]
 
-    @NLconstraint(pm.model, p_to ==  g_to[h]*vm_to[h]^2 + sum(
-                                        g[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) +
-                                        b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) -
-                                        g[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) -
-                                        b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) )
-    @NLconstraint(pm.model, q_to == -b_to[h]*vm_to[h]^2 - sum(
-                                        b[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) -
-                                        g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) -
-                                        b[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
+    @NLconstraint(pm.model, p_to == (g_to[h]+g[h,h])*vm_to[h]^2 +
+                                   sum( g[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) +
+                                        b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.phase_ids(pm) if i != h) +
+                                   sum(-g[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
+                                       -b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) )
+    @NLconstraint(pm.model, q_to == -(b_to[h]+b[h,h])*vm_to[h]^2 -
+                                   sum( b[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) -
+                                        g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.phase_ids(pm) if i != h) -
+                                   sum(-b[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
                                         g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) )
 end
 

--- a/src/prob/tp_pf.jl
+++ b/src/prob/tp_pf.jl
@@ -30,6 +30,7 @@ end
 function post_tp_pf(pm::GenericPowerModel)
     for h in PMs.phase_ids(pm)
         variable_tp_voltage(pm, bounded=false, ph=h)
+        # PMs.variable_voltage(pm, bounded=false, ph=h)
         PMs.variable_generation(pm, bounded=false, ph=h)
         PMs.variable_branch_flow(pm, bounded=false, ph=h)
         PMs.variable_dcline_flow(pm, bounded=false, ph=h)
@@ -37,10 +38,12 @@ function post_tp_pf(pm::GenericPowerModel)
 
     for h in PMs.phase_ids(pm)
         constraint_tp_voltage(pm, ph=h)
+        # PMs.constraint_voltage(pm, ph=h)
 
         for (i,bus) in ref(pm, :ref_buses)
             @assert bus["bus_type"] == 3
             constraint_tp_theta_ref(pm, i, ph=h)
+            # PMs.constraint_theta_ref(pm, i, ph=h)
             PMs.constraint_voltage_magnitude_setpoint(pm, i, ph=h)
         end
 
@@ -62,6 +65,8 @@ function post_tp_pf(pm::GenericPowerModel)
         for i in ids(pm, :branch)
             constraint_ohms_tp_yt_from(pm, i, ph=h)
             constraint_ohms_tp_yt_to(pm, i, ph=h)
+            # PMs.constraint_ohms_yt_from(pm, i, ph=h)
+            # PMs.constraint_ohms_yt_to(pm, i, ph=h)
         end
 
         for (i,dcline) in ref(pm, :dcline)

--- a/src/prob/tp_pf.jl
+++ b/src/prob/tp_pf.jl
@@ -48,7 +48,7 @@ function post_tp_pf(pm::GenericPowerModel)
         end
 
         for (i,bus) in ref(pm, :bus)
-            PMs.constraint_kcl_shunt(pm, i)
+            PMs.constraint_kcl_shunt(pm, i, ph=h)
 
             # PV Bus Constraints
             if length(ref(pm, :bus_gens, i)) > 0 && !(i in ids(pm,:ref_buses))

--- a/test/data/opendss/case2_diag.dss
+++ b/test/data/opendss/case2_diag.dss
@@ -1,0 +1,29 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50 ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.000    0.1000 |  0.000    0.000    0.1000)
+~ xmatrix = ( 0.1 |  0.0    0.1 | 0.0    0.0    0.1)
+~ cmatrix = ( 0  | -0  0 | -0 -0 0  ) ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+
+!Loads - single phase
+
+New Load.L1 phases=1  Primary.1.0   0.23   kW=6   kvar=0  model=1
+New Load.L2 phases=1  Primary.2.0   0.23   kW=6   kvar=0  model=1
+New Load.L3 phases=1  Primary.3.0   0.23   kW=6   kvar=0  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+Calcvoltagebases
+
+Solve

--- a/test/data/opendss/test_simple.dss
+++ b/test/data/opendss/test_simple.dss
@@ -5,6 +5,6 @@ new circuit.Simple
 
 new line.branch1 bus1=sourcebus bus2=2
 
-new generator.gen1 bus1=sourcebus
+new generator.gen1 bus1=2
 
 new load.load1 bus1=2

--- a/test/tp_pf.jl
+++ b/test/tp_pf.jl
@@ -19,4 +19,49 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0.0; atol=1e-2)
     end
+
+    @testset "2-bus diagonal" begin
+        tppm = TPPMs.parse_file("../test/data/opendss/case2_diag.dss")
+        sol = TPPMs.run_tp_pf(tppm, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["status"] == :LocalOptimal
+
+        @test all(isapprox.(sol["solution"]["bus"]["2"]["vm"].values, 0.984377; atol=1e-4))
+        @test all(isapprox.(sol["solution"]["bus"]["2"]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) - deg2rad(0.79) for ph in 1:tppm["phases"]]; atol=deg2rad(0.2)))
+
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018209; atol=1e-5)
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.000208979; atol=1e-5)
+    end
+
+    @testset "3-bus balanced" begin
+        tppm = TPPMs.parse_file("../test/data/opendss/case3_balanced.dss")
+        sol = TPPMs.run_tp_pf(tppm, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["status"] == :LocalOptimal
+
+        for (bus, va, vm) in zip(["1", "2", "3"], [0.0, deg2rad(-0.08), deg2rad(-0.17)], [0.9959, 0.986559, 0.97572])
+            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) + va for ph in 1:tppm["phases"]]; atol=deg2rad(0.2)))
+            @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=1e-3))
+        end
+
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0183456; atol=1e-5)
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00923328; atol=1e-4)
+    end
+
+    @testset "3-bus unbalanced" begin
+        tppm = TPPMs.parse_file("../test/data/opendss/case3_unbalanced.dss")
+        sol = TPPMs.run_tp_pf(tppm, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["status"] == :LocalOptimal
+
+        for (bus, va, vm) in zip(["1", "2", "3"],
+                                [0.0, deg2rad.([-0.30, 0.09, -0.17]), deg2rad.([-0.65, 0.20, -0.36])],
+                                [0.9959, [0.980269, 0.986645, 0.989161], [0.962159, 0.975897, 0.981341]])
+            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) for ph in 1:tppm["phases"]] + va; atol=deg2rad(0.2)))
+            @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=2e-3))
+        end
+
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0214835; atol=1e-5)
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00932693; atol=1e-4)
+    end
 end


### PR DESCRIPTION
Fixes parsing of OpenDSS lines. Units of `rmatrix`, `xmatrix`, `cmatrix`,
`b_fr` and `b_to` were 1/MVA, instead of pu, fixed now. Adds factor 3
to `rmatrix` and `xmatrix`. Refactors handling of `Rg`, `Xg` in
`createLine`.

Fixes bug in bus parsing; vmin and vmax were being overwritten in the
for-loop, changed variable names to fix this.

Adds unit tests to ensure better parity with results of OpenDSS. Adds
new 2-bus test with only diagonal elements in `rmatrix` and `xmatrix`.
Tightens tolerances on existing unit test on 3-bus balanced and
unbalanced cases. Adjusts simple test case to move generator from
sourcebus to bus 2.

Fixes a typo in `src/prob/tp_pf.jl` that was causing PowerFlow problems
based on OpenDSS data to fail.

Adds new powerflow tests based on OpenDSS data.