### PR TITLE
Multi-conductor Rename

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -2,13 +2,13 @@
 
 
 ""
-function constraint_tp_voltage(pm::GenericPowerModel; nw::Int=pm.cnw, ph::Int=pm.cph)
-    constraint_tp_voltage(pm, nw, ph)
+function constraint_tp_voltage(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_tp_voltage(pm, nw, cnd)
 end
 
 
 ""
-function constraint_ohms_tp_yt_from(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, ph::Int=pm.cph)
+function constraint_ohms_tp_yt_from(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -21,12 +21,12 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel, i::Int; nw::Int=pm.cn
     b_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    constraint_ohms_tp_yt_from(pm, nw, ph, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
+    constraint_ohms_tp_yt_from(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
 end
 
 
 ""
-function constraint_ohms_tp_yt_to(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, ph::Int=pm.cph)
+function constraint_ohms_tp_yt_to(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -39,12 +39,12 @@ function constraint_ohms_tp_yt_to(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw,
     b_to = branch["b_to"]
     tm = branch["tap"]
 
-    constraint_ohms_tp_yt_to(pm, nw, ph, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
+    constraint_ohms_tp_yt_to(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
 end
 
 
 ""
-function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, ph::Int=pm.cph)
+function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -57,15 +57,15 @@ function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel, i::Int; nw::In
     b_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    vad_min = [ref(pm, nw, :off_angmin, j) for j in PMs.phase_ids(pm)]
-    vad_max = [ref(pm, nw, :off_angmax, j) for j in PMs.phase_ids(pm)]
+    vad_min = [ref(pm, nw, :off_angmin, j) for j in PMs.conductor_ids(pm)]
+    vad_max = [ref(pm, nw, :off_angmax, j) for j in PMs.conductor_ids(pm)]
 
-    constraint_ohms_tp_yt_from_on_off(pm, nw, ph, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
+    constraint_ohms_tp_yt_from_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
 end
 
 
 ""
-function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, ph::Int=pm.cph)
+function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -78,21 +78,21 @@ function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel, i::Int; nw::Int=
     b_to = branch["b_to"]
     tm = branch["tap"]
 
-    vad_min = [ref(pm, nw, :off_angmin, j) for j in PMs.phase_ids(pm)]
-    vad_max = [ref(pm, nw, :off_angmax, j) for j in PMs.phase_ids(pm)]
+    vad_min = [ref(pm, nw, :off_angmin, j) for j in PMs.conductor_ids(pm)]
+    vad_max = [ref(pm, nw, :off_angmax, j) for j in PMs.conductor_ids(pm)]
 
-    constraint_ohms_tp_yt_to_on_off(pm, nw, ph, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
+    constraint_ohms_tp_yt_to_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
 end
 
 
 ""
-function constraint_tp_theta_ref(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, ph::Int=pm.cph)
-    constraint_tp_theta_ref(pm, nw, ph, i)
+function constraint_tp_theta_ref(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_tp_theta_ref(pm, nw, cnd, i)
 end
 
 
 ""
-function constraint_tp_voltage_magnitude_difference(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, ph::Int=pm.cph)
+function constraint_tp_voltage_magnitude_difference(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -105,5 +105,5 @@ function constraint_tp_voltage_magnitude_difference(pm::GenericPowerModel, i::In
     b_sh_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    constraint_tp_voltage_magnitude_difference(pm, nw, ph, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
+    constraint_tp_voltage_magnitude_difference(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -57,8 +57,8 @@ function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel, i::Int; nw::In
     b_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    vad_min = [ref(pm, nw, :off_angmin, j) for j in PMs.conductor_ids(pm)]
-    vad_max = [ref(pm, nw, :off_angmax, j) for j in PMs.conductor_ids(pm)]
+    vad_min = [ref(pm, nw, :off_angmin, c) for c in PMs.conductor_ids(pm)]
+    vad_max = [ref(pm, nw, :off_angmax, c) for c in PMs.conductor_ids(pm)]
 
     constraint_ohms_tp_yt_from_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
 end
@@ -78,8 +78,8 @@ function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel, i::Int; nw::Int=
     b_to = branch["b_to"]
     tm = branch["tap"]
 
-    vad_min = [ref(pm, nw, :off_angmin, j) for j in PMs.conductor_ids(pm)]
-    vad_max = [ref(pm, nw, :off_angmax, j) for j in PMs.conductor_ids(pm)]
+    vad_min = [ref(pm, nw, :off_angmin, c) for c in PMs.conductor_ids(pm)]
+    vad_max = [ref(pm, nw, :off_angmax, c) for c in PMs.conductor_ids(pm)]
 
     constraint_ohms_tp_yt_to_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
 end

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -5,25 +5,25 @@ function calc_tp_voltage_product_bounds(pm::GenericPowerModel, buspairs; nw::Int
     wi_min = Dict([(bp, -Inf) for bp in buspairs])
     wi_max = Dict([(bp,  Inf) for bp in buspairs])
 
-    for (i, j, h, g) in buspairs
+    for (i, j, c, d) in buspairs
         if i == j
             bus = ref(pm, nw, :bus)[i]
-            vm_fr_max = bus["vmax"][h]
-            vm_to_max = bus["vmax"][g]
-            vm_fr_min = bus["vmin"][h]
-            vm_to_min = bus["vmin"][g]
+            vm_fr_max = bus["vmax"][c]
+            vm_to_max = bus["vmax"][d]
+            vm_fr_min = bus["vmin"][c]
+            vm_to_min = bus["vmin"][d]
         else
             buspair = ref(pm, nw, :buspairs)[(i, j)]
-            vm_fr_max = buspair["vm_fr_max"][h]
-            vm_to_max = buspair["vm_to_max"][g]
-            vm_fr_min = buspair["vm_fr_min"][h]
-            vm_to_min = buspair["vm_to_min"][g]
+            vm_fr_max = buspair["vm_fr_max"][c]
+            vm_to_max = buspair["vm_to_max"][d]
+            vm_fr_min = buspair["vm_fr_min"][c]
+            vm_to_min = buspair["vm_to_min"][d]
         end
 
-        wr_max[(i, j, h, g)] =  vm_fr_max * vm_to_max
-        wr_min[(i, j, h, g)] = -vm_fr_max * vm_to_max
-        wi_max[(i, j, h, g)] =  vm_fr_max * vm_to_max
-        wi_min[(i, j, h, g)] = -vm_fr_max * vm_to_max
+        wr_max[(i, j, c, d)] =  vm_fr_max * vm_to_max
+        wr_min[(i, j, c, d)] = -vm_fr_max * vm_to_max
+        wi_max[(i, j, c, d)] =  vm_fr_max * vm_to_max
+        wi_min[(i, j, c, d)] = -vm_fr_max * vm_to_max
     end
 
     return wr_min, wr_max, wi_min, wi_max

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -1,61 +1,61 @@
 "variable: `w[i] >= 0` for `i` in `bus`es"
-function variable_tp_voltage_magnitude_sqr(pm::GenericPowerModel; nw::Int=pm.cnw, ph::Int=pm.cph, bounded=true)
-    bus_ph = [(i, h) for i in ids(pm, nw, :bus) for h in PMs.phase_ids(pm)]
+function variable_tp_voltage_magnitude_sqr(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+    bus_cnd = [(i, c) for i in ids(pm, nw, :bus) for c in PMs.conductor_ids(pm)]
 
     if bounded
         W = var(pm, nw)[:w] = @variable(pm.model,
-            [i in bus_ph], basename="$(nw)_w",
+            [i in bus_cnd], basename="$(nw)_w",
             lowerbound = ref(pm, nw, :bus, i[1], "vmin", i[2])^2,
             upperbound = ref(pm, nw, :bus, i[1], "vmax", i[2])^2,
             start = PMs.getval(ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
         )
     else
         W = var(pm, nw)[:w] = @variable(pm.model,
-            [i in bus_ph], basename="$(nw)_w",
+            [i in bus_cnd], basename="$(nw)_w",
             lowerbound = 0,
             start = PMs.getval(ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
         )
     end
 
-    var(pm, nw, ph)[:w] = Dict{Int,Any}()
+    var(pm, nw, cnd)[:w] = Dict{Int,Any}()
     for i in ids(pm, nw, :bus)
-        var(pm, nw, ph, :w)[i] = W[(i, ph)]
+        var(pm, nw, cnd, :w)[i] = W[(i, cnd)]
     end
 end
 
 
 ""
-function variable_tp_voltage_product(pm::GenericPowerModel; nw::Int=pm.cnw, ph::Int=pm.cph, bounded=true)
-    bp_phf_pht = [(i, j, h, g) for (i,j) in keys(ref(pm, nw, :buspairs)) for h in PMs.phase_ids(pm) for g in PMs.phase_ids(pm)]
-    bus_ph = [(i, i, h, g) for i in ids(pm, nw, :bus) for h in PMs.phase_ids(pm) for g in PMs.phase_ids(pm) if h != g]
-    append!(bus_ph, bp_phf_pht)
+function variable_tp_voltage_product(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+    bp_cndf_cndt = [(i, j, c, d) for (i,j) in keys(ref(pm, nw, :buspairs)) for c in PMs.conductor_ids(pm) for d in PMs.conductor_ids(pm)]
+    bus_cnd = [(i, i, c, d) for i in ids(pm, nw, :bus) for c in PMs.conductor_ids(pm) for d in PMs.conductor_ids(pm) if c != d]
+    append!(bus_cnd, bp_cndf_cndt)
 
     WR = var(pm, nw)[:wr] = @variable(pm.model,
-        [b in bus_ph], basename="$(nw)_wr",
+        [b in bus_cnd], basename="$(nw)_wr",
         start = PMs.getval(b[1] != b[2] ? ref(pm, nw, :buspairs, b[1:2]) : ref(pm, nw, :bus, b[1]), "wr_start", b[3], 1.0)
     )
 
     WI = var(pm, nw)[:wi] = @variable(pm.model,
-        [b in bus_ph], basename="$(nw)_wi",
+        [b in bus_cnd], basename="$(nw)_wi",
         start = PMs.getval(b[1] != b[2] ? ref(pm, nw, :buspairs, b[1:2]) : ref(pm, nw, :bus, b[1]), "wi_start", b[3])
     )
 
     if bounded
         # Diagonal bounds
-        wr_min, wr_max, wi_min, wi_max = PMs.calc_voltage_product_bounds(ref(pm, nw, :buspairs), ph)
+        wr_min, wr_max, wi_min, wi_max = PMs.calc_voltage_product_bounds(ref(pm, nw, :buspairs), cnd)
         for (i, j) in ids(pm, nw, :buspairs)
-            PMs.setupperbound(WR[(i, j, ph, ph)], wr_max[(i,j)])
-            PMs.setupperbound(WI[(i, j, ph, ph)], wi_max[(i,j)])
+            PMs.setupperbound(WR[(i, j, cnd, cnd)], wr_max[(i,j)])
+            PMs.setupperbound(WI[(i, j, cnd, cnd)], wi_max[(i,j)])
 
-            PMs.setlowerbound(WR[(i, j, ph, ph)], wr_min[(i,j)])
-            PMs.setlowerbound(WI[(i, j, ph, ph)], wi_min[(i,j)])
+            PMs.setlowerbound(WR[(i, j, cnd, cnd)], wr_min[(i,j)])
+            PMs.setlowerbound(WI[(i, j, cnd, cnd)], wi_min[(i,j)])
         end
 
         # Off-diagonal bounds
-        for h in PMs.phase_ids(pm)
-            if h != ph
-                wr_min, wr_max, wi_min, wi_max = calc_tp_voltage_product_bounds(pm, bus_ph)
-                for k in bus_ph
+        for c in PMs.conductor_ids(pm)
+            if c != cnd
+                wr_min, wr_max, wi_min, wi_max = calc_tp_voltage_product_bounds(pm, bus_cnd)
+                for k in bus_cnd
                     PMs.setupperbound(WR[k], wr_max[k])
                     PMs.setupperbound(WI[k], wi_max[k])
 
@@ -66,10 +66,10 @@ function variable_tp_voltage_product(pm::GenericPowerModel; nw::Int=pm.cnw, ph::
         end
     end
 
-    var(pm, nw, ph)[:wr] = Dict{Tuple{Int,Int},Any}()
-    var(pm, nw, ph)[:wi] = Dict{Tuple{Int,Int},Any}()
+    var(pm, nw, cnd)[:wr] = Dict{Tuple{Int,Int},Any}()
+    var(pm, nw, cnd)[:wi] = Dict{Tuple{Int,Int},Any}()
     for (i, j) in ids(pm, nw, :buspairs)
-        var(pm, nw, ph, :wr)[(i,j)] = WR[(i, j, ph, ph)]
-        var(pm, nw, ph, :wi)[(i,j)] = WI[(i, j, ph, ph)]
+        var(pm, nw, cnd, :wr)[(i,j)] = WR[(i, j, cnd, cnd)]
+        var(pm, nw, cnd, :wi)[(i,j)] = WI[(i, j, cnd, cnd)]
     end
 end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -28,15 +28,15 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
     va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
 
     @NLconstraint(pm.model, p_fr ==  (g_fr[c]+g[c,c]) * vm_fr[c]^2 +
-                                    sum( g[c,i]*vm_fr[c]*vm_fr[i]*cos(va_fr[c]-va_fr[i]) +
-                                         b[c,i]*vm_fr[c]*vm_fr[i]*sin(va_fr[c]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != c) +
-                                    sum(-g[c,i]*vm_fr[c]*vm_to[i]*cos(va_fr[c]-va_to[i]) +
-                                        -b[c,i]*vm_fr[c]*vm_to[i]*sin(va_fr[c]-va_to[i]) for i in PMs.conductor_ids(pm)) )
+                                    sum( g[c,d]*vm_fr[c]*vm_fr[d]*cos(va_fr[c]-va_fr[d]) +
+                                         b[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in PMs.conductor_ids(pm) if d != c) +
+                                    sum(-g[c,d]*vm_fr[c]*vm_to[d]*cos(va_fr[c]-va_to[d]) +
+                                        -b[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in PMs.conductor_ids(pm)) )
     @NLconstraint(pm.model, q_fr == -(b_fr[c]+b[c,c]) *vm_fr[c]^2 -
-                                    sum( b[c,i]*vm_fr[c]*vm_fr[i]*cos(va_fr[c]-va_fr[i]) -
-                                         g[c,i]*vm_fr[c]*vm_fr[i]*sin(va_fr[c]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != c) -
-                                    sum(-b[c,i]*vm_fr[c]*vm_to[i]*cos(va_fr[c]-va_to[i]) +
-                                         g[c,i]*vm_fr[c]*vm_to[i]*sin(va_fr[c]-va_to[i]) for i in PMs.conductor_ids(pm)) )
+                                    sum( b[c,d]*vm_fr[c]*vm_fr[d]*cos(va_fr[c]-va_fr[d]) -
+                                         g[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in PMs.conductor_ids(pm) if d != c) -
+                                    sum(-b[c,d]*vm_fr[c]*vm_to[d]*cos(va_fr[c]-va_to[d]) +
+                                         g[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in PMs.conductor_ids(pm)) )
 end
 
 
@@ -51,21 +51,21 @@ q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bu
 function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
     p_to  = var(pm, n, c,  :p, t_idx)
     q_to  = var(pm, n, c,  :q, t_idx)
-    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
-    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
+    vm_fr = [var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
     va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
     va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
 
     @NLconstraint(pm.model, p_to == (g_to[c]+g[c,c])*vm_to[c]^2 +
-                                   sum( g[c,i]*vm_to[c]*vm_to[i]*cos(va_to[c]-va_to[i]) +
-                                        b[c,i]*vm_to[c]*vm_to[i]*sin(va_to[c]-va_to[i]) for i in PMs.conductor_ids(pm) if i != c) +
-                                   sum(-g[c,i]*vm_to[c]*vm_fr[i]*cos(va_to[c]-va_fr[i]) +
-                                       -b[c,i]*vm_to[c]*vm_fr[i]*sin(va_to[c]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
+                                   sum( g[c,d]*vm_to[c]*vm_to[d]*cos(va_to[c]-va_to[d]) +
+                                        b[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in PMs.conductor_ids(pm) if d != c) +
+                                   sum(-g[c,d]*vm_to[c]*vm_fr[d]*cos(va_to[c]-va_fr[d]) +
+                                       -b[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in PMs.conductor_ids(pm)) )
     @NLconstraint(pm.model, q_to == -(b_to[c]+b[c,c])*vm_to[c]^2 -
-                                   sum( b[c,i]*vm_to[c]*vm_to[i]*cos(va_to[c]-va_to[i]) -
-                                        g[c,i]*vm_to[c]*vm_to[i]*sin(va_to[c]-va_to[i]) for i in PMs.conductor_ids(pm) if i != c) -
-                                   sum(-b[c,i]*vm_to[c]*vm_fr[i]*cos(va_to[c]-va_fr[i]) +
-                                        g[c,i]*vm_to[c]*vm_fr[i]*sin(va_to[c]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
+                                   sum( b[c,d]*vm_to[c]*vm_to[d]*cos(va_to[c]-va_to[d]) -
+                                        g[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in PMs.conductor_ids(pm) if d != c) -
+                                   sum(-b[c,d]*vm_to[c]*vm_fr[d]*cos(va_to[c]-va_fr[d]) +
+                                        g[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in PMs.conductor_ids(pm)) )
 end
 
 
@@ -78,8 +78,8 @@ q[f_idx] == z*(-(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t
 function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
     p_fr  = var(pm, n, c,  :p, f_idx)
     q_fr  = var(pm, n, c,  :q, f_idx)
-    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
-    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
+    vm_fr = [var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
     va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
     va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
     z = var(pm, n, c, :branch_z, i)
@@ -105,8 +105,8 @@ q[t_idx] == z*(-(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_
 function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
     p_to  = var(pm, n, c,  :p, t_idx)
     q_to  = var(pm, n, c,  :q, t_idx)
-    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
-    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
+    vm_fr = [var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
     va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
     va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
     z = var(pm, n, c, :branch_z, i)

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -22,21 +22,21 @@ q[f_idx] == -(b+b_fr)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f
 function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractACPForm
     p_fr  = var(pm, n, h,  :p, f_idx)
     q_fr  = var(pm, n, h,  :q, f_idx)
-    vm_fr = [var(pm, n, j, :vm, f_bus) for j in PMs.phase_ids(pm)]
-    vm_to = [var(pm, n, j, :vm, t_bus) for j in PMs.phase_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.phase_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.phase_ids(pm)]
+    vm_fr = [var(pm, n, j, :vm, f_bus) for j in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, j, :vm, t_bus) for j in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
 
     @NLconstraint(pm.model, p_fr ==  (g_fr[h]+g[h,h]) * vm_fr[h]^2 +
                                     sum( g[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) +
-                                         b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.phase_ids(pm) if i != h) +
+                                         b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != h) +
                                     sum(-g[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                        -b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) )
+                                        -b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) )
     @NLconstraint(pm.model, q_fr == -(b_fr[h]+b[h,h]) *vm_fr[h]^2 -
                                     sum( b[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) -
-                                         g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.phase_ids(pm) if i != h) -
+                                         g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != h) -
                                     sum(-b[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                         g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) )
+                                         g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) )
 end
 
 
@@ -51,21 +51,21 @@ q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bu
 function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
     p_to  = var(pm, n, h,  :p, t_idx)
     q_to  = var(pm, n, h,  :q, t_idx)
-    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.phase_ids(pm)]
-    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.phase_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.phase_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.phase_ids(pm)]
+    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
 
     @NLconstraint(pm.model, p_to == (g_to[h]+g[h,h])*vm_to[h]^2 +
                                    sum( g[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) +
-                                        b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.phase_ids(pm) if i != h) +
+                                        b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.conductor_ids(pm) if i != h) +
                                    sum(-g[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
-                                       -b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) )
+                                       -b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
     @NLconstraint(pm.model, q_to == -(b_to[h]+b[h,h])*vm_to[h]^2 -
                                    sum( b[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) -
-                                        g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.phase_ids(pm) if i != h) -
+                                        g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.conductor_ids(pm) if i != h) -
                                    sum(-b[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
-                                        g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) )
+                                        g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
 end
 
 
@@ -78,22 +78,22 @@ q[f_idx] == z*(-(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t
 function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
     p_fr  = var(pm, n, h,  :p, f_idx)
     q_fr  = var(pm, n, h,  :q, f_idx)
-    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.phase_ids(pm)]
-    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.phase_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.phase_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.phase_ids(pm)]
+    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
     z = var(pm, n, h, :branch_z, i)
 
     @NLconstraint(pm.model, p_fr == z*( g_fr[h]*vm_fr[h]^2 + sum(
                                             g[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) +
                                             b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) -
                                             g[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) -
-                                            b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) ) )
+                                            b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) ) )
     @NLconstraint(pm.model, q_fr == z*(-b_fr[h]*vm_fr[h]^2 - sum(
                                             b[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) -
                                             g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) -
                                             b[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                            g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.phase_ids(pm)) ) )
+                                            g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) ) )
 end
 
 """
@@ -105,20 +105,20 @@ q[t_idx] == z*(-(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_
 function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
     p_to  = var(pm, n, h,  :p, t_idx)
     q_to  = var(pm, n, h,  :q, t_idx)
-    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.phase_ids(pm)]
-    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.phase_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.phase_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.phase_ids(pm)]
+    vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
     z = var(pm, n, h, :branch_z, i)
 
     @NLconstraint(pm.model, p_to == z*( g_to[h]*vm_to[h]^2 + sum(
                                         g[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) +
                                         b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) -
                                         g[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) -
-                                        b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) ) )
+                                        b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) ) )
     @NLconstraint(pm.model, q_to == z*(-b_to[h]*vm_to[h]^2 - sum(
                                         b[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) -
                                         g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) -
                                         b[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
-                                        g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.phase_ids(pm)) ) )
+                                        g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) ) )
 end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -19,24 +19,24 @@ p[f_idx] ==  (g+g_fr)/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f
 q[f_idx] == -(b+b_fr)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus]))
 ```
 """
-function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractACPForm
-    p_fr  = var(pm, n, h,  :p, f_idx)
-    q_fr  = var(pm, n, h,  :q, f_idx)
-    vm_fr = [var(pm, n, j, :vm, f_bus) for j in PMs.conductor_ids(pm)]
-    vm_to = [var(pm, n, j, :vm, t_bus) for j in PMs.conductor_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
+function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractACPForm
+    p_fr  = var(pm, n, c,  :p, f_idx)
+    q_fr  = var(pm, n, c,  :q, f_idx)
+    vm_fr = [var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
 
-    @NLconstraint(pm.model, p_fr ==  (g_fr[h]+g[h,h]) * vm_fr[h]^2 +
-                                    sum( g[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) +
-                                         b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != h) +
-                                    sum(-g[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                        -b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) )
-    @NLconstraint(pm.model, q_fr == -(b_fr[h]+b[h,h]) *vm_fr[h]^2 -
-                                    sum( b[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) -
-                                         g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != h) -
-                                    sum(-b[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                         g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) )
+    @NLconstraint(pm.model, p_fr ==  (g_fr[c]+g[c,c]) * vm_fr[c]^2 +
+                                    sum( g[c,i]*vm_fr[c]*vm_fr[i]*cos(va_fr[c]-va_fr[i]) +
+                                         b[c,i]*vm_fr[c]*vm_fr[i]*sin(va_fr[c]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != c) +
+                                    sum(-g[c,i]*vm_fr[c]*vm_to[i]*cos(va_fr[c]-va_to[i]) +
+                                        -b[c,i]*vm_fr[c]*vm_to[i]*sin(va_fr[c]-va_to[i]) for i in PMs.conductor_ids(pm)) )
+    @NLconstraint(pm.model, q_fr == -(b_fr[c]+b[c,c]) *vm_fr[c]^2 -
+                                    sum( b[c,i]*vm_fr[c]*vm_fr[i]*cos(va_fr[c]-va_fr[i]) -
+                                         g[c,i]*vm_fr[c]*vm_fr[i]*sin(va_fr[c]-va_fr[i]) for i in PMs.conductor_ids(pm) if i != c) -
+                                    sum(-b[c,i]*vm_fr[c]*vm_to[i]*cos(va_fr[c]-va_to[i]) +
+                                         g[c,i]*vm_fr[c]*vm_to[i]*sin(va_fr[c]-va_to[i]) for i in PMs.conductor_ids(pm)) )
 end
 
 
@@ -48,24 +48,24 @@ p[t_idx] ==  (g+g_to)*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bu
 q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
-    p_to  = var(pm, n, h,  :p, t_idx)
-    q_to  = var(pm, n, h,  :q, t_idx)
+function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
+    p_to  = var(pm, n, c,  :p, t_idx)
+    q_to  = var(pm, n, c,  :q, t_idx)
     vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
     vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
 
-    @NLconstraint(pm.model, p_to == (g_to[h]+g[h,h])*vm_to[h]^2 +
-                                   sum( g[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) +
-                                        b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.conductor_ids(pm) if i != h) +
-                                   sum(-g[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
-                                       -b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
-    @NLconstraint(pm.model, q_to == -(b_to[h]+b[h,h])*vm_to[h]^2 -
-                                   sum( b[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) -
-                                        g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) for i in PMs.conductor_ids(pm) if i != h) -
-                                   sum(-b[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
-                                        g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
+    @NLconstraint(pm.model, p_to == (g_to[c]+g[c,c])*vm_to[c]^2 +
+                                   sum( g[c,i]*vm_to[c]*vm_to[i]*cos(va_to[c]-va_to[i]) +
+                                        b[c,i]*vm_to[c]*vm_to[i]*sin(va_to[c]-va_to[i]) for i in PMs.conductor_ids(pm) if i != c) +
+                                   sum(-g[c,i]*vm_to[c]*vm_fr[i]*cos(va_to[c]-va_fr[i]) +
+                                       -b[c,i]*vm_to[c]*vm_fr[i]*sin(va_to[c]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
+    @NLconstraint(pm.model, q_to == -(b_to[c]+b[c,c])*vm_to[c]^2 -
+                                   sum( b[c,i]*vm_to[c]*vm_to[i]*cos(va_to[c]-va_to[i]) -
+                                        g[c,i]*vm_to[c]*vm_to[i]*sin(va_to[c]-va_to[i]) for i in PMs.conductor_ids(pm) if i != c) -
+                                   sum(-b[c,i]*vm_to[c]*vm_fr[i]*cos(va_to[c]-va_fr[i]) +
+                                        g[c,i]*vm_to[c]*vm_fr[i]*sin(va_to[c]-va_fr[i]) for i in PMs.conductor_ids(pm)) )
 end
 
 
@@ -75,25 +75,25 @@ p[f_idx] == z*(g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]
 q[f_idx] == z*(-(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus])))
 ```
 """
-function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
-    p_fr  = var(pm, n, h,  :p, f_idx)
-    q_fr  = var(pm, n, h,  :q, f_idx)
+function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
+    p_fr  = var(pm, n, c,  :p, f_idx)
+    q_fr  = var(pm, n, c,  :q, f_idx)
     vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
     vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
-    z = var(pm, n, h, :branch_z, i)
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+    z = var(pm, n, c, :branch_z, i)
 
-    @NLconstraint(pm.model, p_fr == z*( g_fr[h]*vm_fr[h]^2 + sum(
-                                            g[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) +
-                                            b[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) -
-                                            g[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) -
-                                            b[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) ) )
-    @NLconstraint(pm.model, q_fr == z*(-b_fr[h]*vm_fr[h]^2 - sum(
-                                            b[h,i]*vm_fr[h]*vm_fr[i]*cos(va_fr[h]-va_fr[i]) -
-                                            g[h,i]*vm_fr[h]*vm_fr[i]*sin(va_fr[h]-va_fr[i]) -
-                                            b[h,i]*vm_fr[h]*vm_to[i]*cos(va_fr[h]-va_to[i]) +
-                                            g[h,i]*vm_fr[h]*vm_to[i]*sin(va_fr[h]-va_to[i]) for i in PMs.conductor_ids(pm)) ) )
+    @NLconstraint(pm.model, p_fr == z*( g_fr[c]*vm_fr[c]^2 + sum(
+                                            g[c,i]*vm_fr[c]*vm_fr[i]*cos(va_fr[c]-va_fr[i]) +
+                                            b[c,i]*vm_fr[c]*vm_fr[i]*sin(va_fr[c]-va_fr[i]) -
+                                            g[c,i]*vm_fr[c]*vm_to[i]*cos(va_fr[c]-va_to[i]) -
+                                            b[c,i]*vm_fr[c]*vm_to[i]*sin(va_fr[c]-va_to[i]) for i in PMs.conductor_ids(pm)) ) )
+    @NLconstraint(pm.model, q_fr == z*(-b_fr[c]*vm_fr[c]^2 - sum(
+                                            b[c,i]*vm_fr[c]*vm_fr[i]*cos(va_fr[c]-va_fr[i]) -
+                                            g[c,i]*vm_fr[c]*vm_fr[i]*sin(va_fr[c]-va_fr[i]) -
+                                            b[c,i]*vm_fr[c]*vm_to[i]*cos(va_fr[c]-va_to[i]) +
+                                            g[c,i]*vm_fr[c]*vm_to[i]*sin(va_fr[c]-va_to[i]) for i in PMs.conductor_ids(pm)) ) )
 end
 
 """
@@ -102,23 +102,23 @@ p[t_idx] == z*(g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[
 q[t_idx] == z*(-(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus])))
 ```
 """
-function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
-    p_to  = var(pm, n, h,  :p, t_idx)
-    q_to  = var(pm, n, h,  :q, t_idx)
+function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
+    p_to  = var(pm, n, c,  :p, t_idx)
+    q_to  = var(pm, n, c,  :q, t_idx)
     vm_fr = [var(pm, n, i, :vm, f_bus) for i in PMs.conductor_ids(pm)]
     vm_to = [var(pm, n, i, :vm, t_bus) for i in PMs.conductor_ids(pm)]
-    va_fr = [var(pm, n, j, :va, f_bus) for j in PMs.conductor_ids(pm)]
-    va_to = [var(pm, n, j, :va, t_bus) for j in PMs.conductor_ids(pm)]
-    z = var(pm, n, h, :branch_z, i)
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+    z = var(pm, n, c, :branch_z, i)
 
-    @NLconstraint(pm.model, p_to == z*( g_to[h]*vm_to[h]^2 + sum(
-                                        g[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) +
-                                        b[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) -
-                                        g[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) -
-                                        b[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) ) )
-    @NLconstraint(pm.model, q_to == z*(-b_to[h]*vm_to[h]^2 - sum(
-                                        b[h,i]*vm_to[h]*vm_to[i]*cos(va_to[h]-va_to[i]) -
-                                        g[h,i]*vm_to[h]*vm_to[i]*sin(va_to[h]-va_to[i]) -
-                                        b[h,i]*vm_to[h]*vm_fr[i]*cos(va_to[h]-va_fr[i]) +
-                                        g[h,i]*vm_to[h]*vm_fr[i]*sin(va_to[h]-va_fr[i]) for i in PMs.conductor_ids(pm)) ) )
+    @NLconstraint(pm.model, p_to == z*( g_to[c]*vm_to[c]^2 + sum(
+                                        g[c,i]*vm_to[c]*vm_to[i]*cos(va_to[c]-va_to[i]) +
+                                        b[c,i]*vm_to[c]*vm_to[i]*sin(va_to[c]-va_to[i]) -
+                                        g[c,i]*vm_to[c]*vm_fr[i]*cos(va_to[c]-va_fr[i]) -
+                                        b[c,i]*vm_to[c]*vm_fr[i]*sin(va_to[c]-va_fr[i]) for i in PMs.conductor_ids(pm)) ) )
+    @NLconstraint(pm.model, q_to == z*(-b_to[c]*vm_to[c]^2 - sum(
+                                        b[c,i]*vm_to[c]*vm_to[i]*cos(va_to[c]-va_to[i]) -
+                                        g[c,i]*vm_to[c]*vm_to[i]*sin(va_to[c]-va_to[i]) -
+                                        b[c,i]*vm_to[c]*vm_fr[i]*cos(va_to[c]-va_fr[i]) +
+                                        g[c,i]*vm_to[c]*vm_fr[i]*sin(va_to[c]-va_fr[i]) for i in PMs.conductor_ids(pm)) ) )
 end

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -24,16 +24,16 @@ end
 """
 Defines voltage drop over a branch, linking from and to side voltage magnitude
 """
-function constraint_tp_voltage_magnitude_difference(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: PMs.AbstractBFForm
-    p_fr = [var(pm, n, j, :p, f_idx) for j in PMs.conductor_ids(pm)]
-    q_fr = [var(pm, n, j, :q, f_idx) for j in PMs.conductor_ids(pm)]
-    w_fr = var(pm, n, h, :w, f_bus)
-    w_to = var(pm, n, h, :w, t_bus)
+function constraint_tp_voltage_magnitude_difference(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: PMs.AbstractBFForm
+    p_fr = [var(pm, n, d, :p, f_idx) for d in PMs.conductor_ids(pm)]
+    q_fr = [var(pm, n, d, :q, f_idx) for d in PMs.conductor_ids(pm)]
+    w_fr = var(pm, n, c, :w, f_bus)
+    w_to = var(pm, n, c, :w, t_bus)
 
     np = length(PMs.conductor_ids(pm))
-    rot = roll([2*pi/np*(j-1) for j in PMs.conductor_ids(pm)], h-1)
+    rot = roll([2*pi/np*(d-1) for d in PMs.conductor_ids(pm)], c-1)
 
     #KVL over the line:
-    @constraint(pm.model, w_to == w_fr - 2*sum((r[h,j]*cos(rot[j])-x[h,j]*sin(rot[j]))*p_fr[j] +
-                                               (r[h,j]*sin(rot[j])+x[h,j]*cos(rot[j]))*q_fr[j] for j in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, w_to == w_fr - 2*sum((r[c,d]*cos(rot[d])-x[c,d]*sin(rot[d]))*p_fr[d] +
+                                               (r[c,d]*sin(rot[d])+x[c,d]*cos(rot[d]))*q_fr[d] for d in PMs.conductor_ids(pm)) )
 end

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -25,15 +25,15 @@ end
 Defines voltage drop over a branch, linking from and to side voltage magnitude
 """
 function constraint_tp_voltage_magnitude_difference(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: PMs.AbstractBFForm
-    p_fr = [var(pm, n, j, :p, f_idx) for j in PMs.phase_ids(pm)]
-    q_fr = [var(pm, n, j, :q, f_idx) for j in PMs.phase_ids(pm)]
+    p_fr = [var(pm, n, j, :p, f_idx) for j in PMs.conductor_ids(pm)]
+    q_fr = [var(pm, n, j, :q, f_idx) for j in PMs.conductor_ids(pm)]
     w_fr = var(pm, n, h, :w, f_bus)
     w_to = var(pm, n, h, :w, t_bus)
 
-    np = length(PMs.phase_ids(pm))
-    rot = roll([2*pi/np*(j-1) for j in PMs.phase_ids(pm)], h-1)
+    np = length(PMs.conductor_ids(pm))
+    rot = roll([2*pi/np*(j-1) for j in PMs.conductor_ids(pm)], h-1)
 
     #KVL over the line:
     @constraint(pm.model, w_to == w_fr - 2*sum((r[h,j]*cos(rot[j])-x[h,j]*sin(rot[j]))*p_fr[j] +
-                                               (r[h,j]*sin(rot[j])+x[h,j]*cos(rot[j]))*q_fr[j] for j in PMs.phase_ids(pm)) )
+                                               (r[h,j]*sin(rot[j])+x[h,j]*cos(rot[j]))*q_fr[j] for j in PMs.conductor_ids(pm)) )
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -7,10 +7,10 @@ p[f_idx] == -b*(t[f_bus] - t[t_bus])
 """
 function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractDCPForm
     p_fr  = var(pm, n, c,  :p, f_idx)
-    va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.conductor_ids(pm)]
-    va_to = [var(pm, n, i, :va, t_bus) for i in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
 
-    @constraint(pm.model, p_fr == -sum(b[c,i]*(va_fr[c] - va_to[i]) for i in PMs.conductor_ids(pm)))
+    @constraint(pm.model, p_fr == -sum(b[c,d]*(va_fr[c] - va_to[d]) for d in PMs.conductor_ids(pm)))
     # omit reactive constraint
 end
 
@@ -23,12 +23,12 @@ end
 "`-b*(t[f_bus] - t[t_bus] + vad_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + vad_max*(1-branch_z[i]))`"
 function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
     p_fr  = var(pm, n, c,  :p, f_idx)
-    va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.conductor_ids(pm)]
-    va_to = [var(pm, n, i, :va, t_bus) for i in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
     z = [var(pm, n, d, :branch_z, i) for d in PMs.conductor_ids(pm)]
 
-    @constraint(pm.model, p_fr <= sum(-b[c,i]*(va_fr[i] - va_to[i] + vad_max[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
-    @constraint(pm.model, p_fr >= sum(-b[c,i]*(va_fr[i] - va_to[i] + vad_min[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_fr <= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_max[d]*(1-z[d])) for d in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_fr >= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_min[d]*(1-z[d])) for d in PMs.conductor_ids(pm)) )
 end
 
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -5,33 +5,33 @@ Creates Ohms constraints (yt post fix indicates that Y and T values are in recta
 p[f_idx] == -b*(t[f_bus] - t[t_bus])
 ```
 """
-function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractDCPForm
-    p_fr  = var(pm, n, h,  :p, f_idx)
+function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractDCPForm
+    p_fr  = var(pm, n, c,  :p, f_idx)
     va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.conductor_ids(pm)]
     va_to = [var(pm, n, i, :va, t_bus) for i in PMs.conductor_ids(pm)]
 
-    @constraint(pm.model, p_fr == -sum(b[h,i]*(va_fr[h] - va_to[i]) for i in PMs.conductor_ids(pm)))
+    @constraint(pm.model, p_fr == -sum(b[c,i]*(va_fr[c] - va_to[i]) for i in PMs.conductor_ids(pm)))
     # omit reactive constraint
 end
 
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractDCPForm
+function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractDCPForm
 end
 
 
 "`-b*(t[f_bus] - t[t_bus] + vad_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + vad_max*(1-branch_z[i]))`"
-function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
-    p_fr  = var(pm, n, h,  :p, f_idx)
+function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
+    p_fr  = var(pm, n, c,  :p, f_idx)
     va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.conductor_ids(pm)]
     va_to = [var(pm, n, i, :va, t_bus) for i in PMs.conductor_ids(pm)]
-    z = [var(pm, n, j, :branch_z, i) for j in PMs.conductor_ids(pm)]
+    z = [var(pm, n, d, :branch_z, i) for d in PMs.conductor_ids(pm)]
 
-    @constraint(pm.model, p_fr <= sum(-b[h,i]*(va_fr[i] - va_to[i] + vad_max[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
-    @constraint(pm.model, p_fr >= sum(-b[h,i]*(va_fr[i] - va_to[i] + vad_min[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_fr <= sum(-b[c,i]*(va_fr[i] - va_to[i] + vad_max[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_fr >= sum(-b[c,i]*(va_fr[i] - va_to[i] + vad_min[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
 end
 
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
+function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -7,10 +7,10 @@ p[f_idx] == -b*(t[f_bus] - t[t_bus])
 """
 function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractDCPForm
     p_fr  = var(pm, n, h,  :p, f_idx)
-    va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.phase_ids(pm)]
-    va_to = [var(pm, n, i, :va, t_bus) for i in PMs.phase_ids(pm)]
+    va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, i, :va, t_bus) for i in PMs.conductor_ids(pm)]
 
-    @constraint(pm.model, p_fr == -sum(b[h,i]*(va_fr[h] - va_to[i]) for i in PMs.phase_ids(pm)))
+    @constraint(pm.model, p_fr == -sum(b[h,i]*(va_fr[h] - va_to[i]) for i in PMs.conductor_ids(pm)))
     # omit reactive constraint
 end
 
@@ -23,12 +23,12 @@ end
 "`-b*(t[f_bus] - t[t_bus] + vad_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + vad_max*(1-branch_z[i]))`"
 function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, h::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
     p_fr  = var(pm, n, h,  :p, f_idx)
-    va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.phase_ids(pm)]
-    va_to = [var(pm, n, i, :va, t_bus) for i in PMs.phase_ids(pm)]
-    z = [var(pm, n, j, :branch_z, i) for j in PMs.phase_ids(pm)]
+    va_fr = [var(pm, n, i, :va, f_bus) for i in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, i, :va, t_bus) for i in PMs.conductor_ids(pm)]
+    z = [var(pm, n, j, :branch_z, i) for j in PMs.conductor_ids(pm)]
 
-    @constraint(pm.model, p_fr <= sum(-b[h,i]*(va_fr[i] - va_to[i] + vad_max[i]*(1-z[i])) for i in PMs.phase_ids(pm)) )
-    @constraint(pm.model, p_fr >= sum(-b[h,i]*(va_fr[i] - va_to[i] + vad_min[i]*(1-z[i])) for i in PMs.phase_ids(pm)) )
+    @constraint(pm.model, p_fr <= sum(-b[h,i]*(va_fr[i] - va_to[i] + vad_max[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_fr >= sum(-b[h,i]*(va_fr[i] - va_to[i] + vad_min[i]*(1-z[i])) for i in PMs.conductor_ids(pm)) )
 end
 
 

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -55,7 +55,7 @@ end
 "Creates phase angle constraints at reference buses"
 function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, i) where T <: PMs.AbstractPForms
     va = var(pm, n, c, :va, i)
-    num_conductors = length(PMs.conductor_ids(pm))
+    nconductors = length(PMs.conductor_ids(pm))
 
-    @constraint(pm.model, va == 2 * pi / num_conductors * (c - 1))
+    @constraint(pm.model, va == 2 * pi / nconductors * (c - 1))
 end

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -4,58 +4,58 @@
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractWRForms
-    p_fr = var(pm, n, h, :p, f_idx)
-    q_fr = var(pm, n, h, :q, f_idx)
+function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractWRForms
+    p_fr = var(pm, n, c, :p, f_idx)
+    q_fr = var(pm, n, c, :q, f_idx)
     w    = var(pm, n, :w)
     wr   = var(pm, n, :wr)
     wi   = var(pm, n, :wi)
 
-    @constraint(pm.model, p_fr ==  ( g_fr[h]+g[h,h]) * w[(f_bus, h)] +
-                                sum( g[h,i] * wr[(f_bus, f_bus, h, i)] +
-                                     b[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) +
-                                sum(-g[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                    -b[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
-    @constraint(pm.model, q_fr == -( b_fr[h]+b[h,h]) * w[(f_bus, h)] -
-                                sum( b[h,i] * wr[(f_bus, f_bus, h, i)] -
-                                     g[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) -
-                                sum(-b[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                     g[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_fr ==  ( g_fr[c]+g[c,c]) * w[(f_bus, c)] +
+                                sum( g[c,i] * wr[(f_bus, f_bus, c, i)] +
+                                     b[c,i] * wi[(f_bus, f_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) +
+                                sum(-g[c,i] * wr[(f_bus, t_bus, c, i)] +
+                                    -b[c,i] * wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, q_fr == -( b_fr[c]+b[c,c]) * w[(f_bus, c)] -
+                                sum( b[c,i] * wr[(f_bus, f_bus, c, i)] -
+                                     g[c,i] * wi[(f_bus, f_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) -
+                                sum(-b[c,i] * wr[(f_bus, t_bus, c, i)] +
+                                     g[c,i] * wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
 end
 
 
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, h::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms
-    q_to = var(pm, n, h, :q, t_idx)
-    p_to = var(pm, n, h, :p, t_idx)
+function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms
+    q_to = var(pm, n, c, :q, t_idx)
+    p_to = var(pm, n, c, :p, t_idx)
     w    = var(pm, n, :w)
     wr   = var(pm, n, :wr)
     wi   = var(pm, n, :wi)
 
-    @constraint(pm.model, p_to ==  ( g_to[h]+g[h,h]) * w[(t_bus, h)] +
-                                sum( g[h,i] * wr[(t_bus, t_bus, h, i)] +
-                                     b[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) +
-                                sum(-g[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                    -b[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
-    @constraint(pm.model, q_to == -( b_to[h]+b[h,h]) * w[(t_bus, h)] -
-                                sum( b[h,i] * wr[(t_bus, t_bus, h, i)] -
-                                     g[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) -
-                                sum(-b[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                     g[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, p_to ==  ( g_to[c]+g[c,c]) * w[(t_bus, c)] +
+                                sum( g[c,i] * wr[(t_bus, t_bus, c, i)] +
+                                     b[c,i] *-wi[(t_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) +
+                                sum(-g[c,i] * wr[(f_bus, t_bus, c, i)] +
+                                    -b[c,i] *-wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+    @constraint(pm.model, q_to == -( b_to[c]+b[c,c]) * w[(t_bus, c)] -
+                                sum( b[c,i] * wr[(t_bus, t_bus, c, i)] -
+                                     g[c,i] *-wi[(t_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) -
+                                sum(-b[c,i] * wr[(f_bus, t_bus, c, i)] +
+                                     g[c,i] *-wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
 end
 
 
 "do nothing, no way to represent this in these variables"
-function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, h::Int, i) where T <: PMs.AbstractWForms
+function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, i) where T <: PMs.AbstractWForms
 end
 
 
 "Creates phase angle constraints at reference buses"
-function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, h::Int, i) where T <: PMs.AbstractPForms
-    va = var(pm, n, h, :va, i)
+function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, i) where T <: PMs.AbstractPForms
+    va = var(pm, n, c, :va, i)
     num_conductors = length(PMs.conductor_ids(pm))
 
-    @constraint(pm.model, va == 2 * pi / num_conductors * (h - 1))
+    @constraint(pm.model, va == 2 * pi / num_conductors * (c - 1))
 end

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -12,15 +12,15 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
     wi   = var(pm, n, :wi)
 
     @constraint(pm.model, p_fr ==  ( g_fr[c]+g[c,c]) * w[(f_bus, c)] +
-                                sum( g[c,i] * wr[(f_bus, f_bus, c, i)] +
-                                     b[c,i] * wi[(f_bus, f_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) +
-                                sum(-g[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                    -b[c,i] * wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( g[c,d] * wr[(f_bus, f_bus, c, d)] +
+                                     b[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                    -b[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_fr == -( b_fr[c]+b[c,c]) * w[(f_bus, c)] -
-                                sum( b[c,i] * wr[(f_bus, f_bus, c, i)] -
-                                     g[c,i] * wi[(f_bus, f_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) -
-                                sum(-b[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                     g[c,i] * wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( b[c,d] * wr[(f_bus, f_bus, c, d)] -
+                                     g[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                     g[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
 end
 
 
@@ -35,26 +35,26 @@ function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bu
     wi   = var(pm, n, :wi)
 
     @constraint(pm.model, p_to ==  ( g_to[c]+g[c,c]) * w[(t_bus, c)] +
-                                sum( g[c,i] * wr[(t_bus, t_bus, c, i)] +
-                                     b[c,i] *-wi[(t_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) +
-                                sum(-g[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                    -b[c,i] *-wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( g[c,d] * wr[(t_bus, t_bus, c, d)] +
+                                     b[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                    -b[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_to == -( b_to[c]+b[c,c]) * w[(t_bus, c)] -
-                                sum( b[c,i] * wr[(t_bus, t_bus, c, i)] -
-                                     g[c,i] *-wi[(t_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) -
-                                sum(-b[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                     g[c,i] *-wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( b[c,d] * wr[(t_bus, t_bus, c, d)] -
+                                     g[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                     g[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
 end
 
 
 "do nothing, no way to represent this in these variables"
-function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, i) where T <: PMs.AbstractWForms
+function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, d) where T <: PMs.AbstractWForms
 end
 
 
 "Creates phase angle constraints at reference buses"
-function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, i) where T <: PMs.AbstractPForms
-    va = var(pm, n, c, :va, i)
+function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, d) where T <: PMs.AbstractPForms
+    va = var(pm, n, c, :va, d)
     nconductors = length(PMs.conductor_ids(pm))
 
     @constraint(pm.model, va == 2 * pi / nconductors * (c - 1))

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -13,14 +13,14 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, h::Int, f_
 
     @constraint(pm.model, p_fr ==  ( g_fr[h]+g[h,h]) * w[(f_bus, h)] +
                                 sum( g[h,i] * wr[(f_bus, f_bus, h, i)] +
-                                     b[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) +
+                                     b[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) +
                                 sum(-g[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                    -b[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                    -b[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_fr == -( b_fr[h]+b[h,h]) * w[(f_bus, h)] -
                                 sum( b[h,i] * wr[(f_bus, f_bus, h, i)] -
-                                     g[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) -
+                                     g[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) -
                                 sum(-b[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                     g[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                     g[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
 end
 
 
@@ -36,14 +36,14 @@ function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, h::Int, f_bu
 
     @constraint(pm.model, p_to ==  ( g_to[h]+g[h,h]) * w[(t_bus, h)] +
                                 sum( g[h,i] * wr[(t_bus, t_bus, h, i)] +
-                                     b[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) +
+                                     b[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) +
                                 sum(-g[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                    -b[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                    -b[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_to == -( b_to[h]+b[h,h]) * w[(t_bus, h)] -
                                 sum( b[h,i] * wr[(t_bus, t_bus, h, i)] -
-                                     g[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) -
+                                     g[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) -
                                 sum(-b[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                     g[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                     g[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
 end
 
 
@@ -55,7 +55,7 @@ end
 "Creates phase angle constraints at reference buses"
 function constraint_tp_theta_ref(pm::GenericPowerModel{T}, n::Int, h::Int, i) where T <: PMs.AbstractPForms
     va = var(pm, n, h, :va, i)
-    nphases = length(PMs.phase_ids(pm))
+    num_conductors = length(PMs.conductor_ids(pm))
 
-    @constraint(pm.model, va == 2 * pi / nphases * (h - 1))
+    @constraint(pm.model, va == 2 * pi / num_conductors * (h - 1))
 end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -44,15 +44,15 @@ function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, c::
     wi   = var(pm, n, :wi)
 
     @constraint(pm.model, p_fr ==  ( g_fr[c]+g[c,c]) * w[(f_bus, c)] +
-                                sum( g[c,i] * wr[(f_bus, f_bus, c, i)] +
-                                     b[c,i] * wi[(f_bus, f_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) +
-                                sum(-g[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                    -b[c,i] * wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( g[c,d] * wr[(f_bus, f_bus, c, d)] +
+                                     b[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                    -b[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_fr == -( b_fr[c]+b[c,c]) * w[(f_bus, c)] -
-                                sum( b[c,i] * wr[(f_bus, f_bus, c, i)] -
-                                     g[c,i] * wi[(f_bus, f_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) -
-                                sum(-b[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                     g[c,i] * wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( b[c,d] * wr[(f_bus, f_bus, c, d)] -
+                                     g[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                     g[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
 end
 
 """
@@ -71,13 +71,13 @@ function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, c::In
     wi   = var(pm, n, :wi)
 
     @constraint(pm.model, p_to ==  ( g_to[c]+g[c,c]) * w[(t_bus, c)] +
-                                sum( g[c,i] * wr[(t_bus, t_bus, c, i)] +
-                                     b[c,i] *-wi[(t_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) +
-                                sum(-g[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                    -b[c,i] *-wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( g[c,d] * wr[(t_bus, t_bus, c, d)] +
+                                     b[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                    -b[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_to == -( b_to[c]+b[c,c]) * w[(t_bus, c)] -
-                                sum( b[c,i] * wr[(t_bus, t_bus, c, i)] -
-                                     g[c,i] *-wi[(t_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm) if i != c) -
-                                sum(-b[c,i] * wr[(f_bus, t_bus, c, i)] +
-                                     g[c,i] *-wi[(f_bus, t_bus, c, i)] for i in PMs.conductor_ids(pm)) )
+                                sum( b[c,d] * wr[(t_bus, t_bus, c, d)] -
+                                     g[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
+                                     g[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
 end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -14,7 +14,7 @@ function constraint_tp_voltage(pm::GenericPowerModel{T}, n::Int, h::Int) where T
     wr = var(pm, n, :wr)
     wi = var(pm, n, :wi)
 
-    for g in h:length(PMs.phase_ids(pm))
+    for g in h:length(PMs.conductor_ids(pm))
         for (i,j) in ids(pm, n, :buspairs)
             InfrastructureModels.relaxation_complex_product(pm.model, w[(i,g)], w[(j,h)], wr[(i,j,h,g)], wi[(i,j,h,g)])
         end
@@ -45,14 +45,14 @@ function constraint_ohms_tp_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, h::
 
     @constraint(pm.model, p_fr ==  ( g_fr[h]+g[h,h]) * w[(f_bus, h)] +
                                 sum( g[h,i] * wr[(f_bus, f_bus, h, i)] +
-                                     b[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) +
+                                     b[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) +
                                 sum(-g[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                    -b[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                    -b[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_fr == -( b_fr[h]+b[h,h]) * w[(f_bus, h)] -
                                 sum( b[h,i] * wr[(f_bus, f_bus, h, i)] -
-                                     g[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) -
+                                     g[h,i] * wi[(f_bus, f_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) -
                                 sum(-b[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                     g[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                     g[h,i] * wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
 end
 
 """
@@ -72,12 +72,12 @@ function constraint_ohms_tp_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, h::In
 
     @constraint(pm.model, p_to ==  ( g_to[h]+g[h,h]) * w[(t_bus, h)] +
                                 sum( g[h,i] * wr[(t_bus, t_bus, h, i)] +
-                                     b[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) +
+                                     b[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) +
                                 sum(-g[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                    -b[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                    -b[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
     @constraint(pm.model, q_to == -( b_to[h]+b[h,h]) * w[(t_bus, h)] -
                                 sum( b[h,i] * wr[(t_bus, t_bus, h, i)] -
-                                     g[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.phase_ids(pm) if i != h) -
+                                     g[h,i] *-wi[(t_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm) if i != h) -
                                 sum(-b[h,i] * wr[(f_bus, t_bus, h, i)] +
-                                     g[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.phase_ids(pm)) )
+                                     g[h,i] *-wi[(f_bus, t_bus, h, i)] for i in PMs.conductor_ids(pm)) )
 end

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -268,7 +268,7 @@ function matlab_to_tppm(ml_data::Dict{String,Any})
 
     ml_data["multinetwork"] = false
     ml_data["per_unit"] = false
-    ml_data["phases"] = 3
+    ml_data["conductors"] = 3
     ml_data["dcline"] = []
 
     # required default values
@@ -341,12 +341,12 @@ end
 "convert raw branch data into arrays"
 function ml2pm_branch(data::Dict{String,Any})
     for branch in data["branch"]
-        branch["rate_a"] = PMs.MultiPhaseVector(branch["rate_a"], 3)
-        branch["rate_b"] = PMs.MultiPhaseVector(branch["rate_b"], 3)
-        branch["rate_c"] = PMs.MultiPhaseVector(branch["rate_c"], 3)
+        branch["rate_a"] = PMs.MultiConductorVector(branch["rate_a"], 3)
+        branch["rate_b"] = PMs.MultiConductorVector(branch["rate_b"], 3)
+        branch["rate_c"] = PMs.MultiConductorVector(branch["rate_c"], 3)
 
-        branch["angmin"] = PMs.MultiPhaseVector(branch["angmin"], 3)
-        branch["angmax"] = PMs.MultiPhaseVector(branch["angmax"], 3)
+        branch["angmin"] = PMs.MultiConductorVector(branch["angmin"], 3)
+        branch["angmax"] = PMs.MultiConductorVector(branch["angmax"], 3)
 
         set_default(branch, "g_fr_1", 0.0)
         set_default(branch, "b_fr_1", 0.0)
@@ -365,20 +365,20 @@ function ml2pm_branch(data::Dict{String,Any})
         make_mpv!(branch, "g_fr", ["g_fr_1", "g_fr_2", "g_fr_3"])
         make_mpv!(branch, "g_to", ["g_to_1", "g_to_2", "g_to_3"])
 
-        branch["b_fr"] = PMs.MultiPhaseVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
-        branch["b_to"] = PMs.MultiPhaseVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
+        branch["b_fr"] = PMs.MultiConductorVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
+        branch["b_to"] = PMs.MultiConductorVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
 
-        branch["tap"] = PMs.MultiPhaseVector(1.0, 3)
-        branch["shift"] = PMs.MultiPhaseVector(0.0, 3)
-        branch["transformer"] = PMs.MultiPhaseVector(false, 3)
+        branch["tap"] = PMs.MultiConductorVector(1.0, 3)
+        branch["shift"] = PMs.MultiConductorVector(0.0, 3)
+        branch["transformer"] = PMs.MultiConductorVector(false, 3)
 
-        branch["br_r"] = PMs.MultiPhaseMatrix([
+        branch["br_r"] = PMs.MultiConductorMatrix([
             branch["r_11"]     branch["r_12"]/2.0 branch["r_13"]/2.0;
             branch["r_12"]/2.0 branch["r_22"]     branch["r_23"]/2.0;
             branch["r_13"]/2.0 branch["r_23"]/2.0 branch["r_33"];
         ])
 
-        branch["br_x"] = PMs.MultiPhaseMatrix([
+        branch["br_x"] = PMs.MultiConductorMatrix([
             branch["x_11"]     branch["x_12"]/2.0 branch["x_13"]/2.0;
             branch["x_12"]/2.0 branch["x_22"]     branch["x_23"]/2.0;
             branch["x_13"]/2.0 branch["x_23"]/2.0 branch["x_33"];
@@ -395,7 +395,7 @@ end
 "collects several from_keys in an array and sets it to the to_key, removes from_keys"
 function make_mpv!(data::Dict{String,Any}, to_key::String, from_keys::Array{String,1})
     assert(!(haskey(data, to_key)))
-    data[to_key] = PMs.MultiPhaseVector([data[k] for k in from_keys])
+    data[to_key] = PMs.MultiConductorVector([data[k] for k in from_keys])
     for k in from_keys
         delete!(data, k)
     end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -20,16 +20,16 @@ function create_starbus(tppm_data::Dict, transformer::Dict)::Dict
 
     base = convert(Int, 10^ceil(log10(abs(PMs.find_max_bus_id(tppm_data)))))
     name, nodes = parse_busname(transformer["buses"][1])
-    phases = tppm_data["conductors"]
+    nconductors = tppm_data["conductors"]
     starbus_id = find_bus(name, tppm_data) + base
 
     starbus["bus_i"] = starbus_id
     starbus["base_kv"] = 1.0
-    starbus["vmin"] = PMs.MultiConductorVector(parse_array(0.9, nodes, phases))
-    starbus["vmax"] = PMs.MultiConductorVector(parse_array(1.1, nodes, phases))
+    starbus["vmin"] = PMs.MultiConductorVector(parse_array(0.9, nodes, nconductors))
+    starbus["vmax"] = PMs.MultiConductorVector(parse_array(1.1, nodes, nconductors))
     starbus["name"] = "$(transformer["name"]) starbus"
-    starbus["vm"] = PMs.MultiConductorVector(parse_array(1.0, nodes, phases))
-    starbus["va"] = PMs.MultiConductorVector(parse_array(0.0, nodes, phases))
+    starbus["vm"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors))
+    starbus["va"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
     starbus["bus_type"] = 1
     starbus["index"] = starbus_id
 

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -25,11 +25,11 @@ function create_starbus(tppm_data::Dict, transformer::Dict)::Dict
 
     starbus["bus_i"] = starbus_id
     starbus["base_kv"] = 1.0
-    starbus["vmin"] = PMs.MultiPhaseVector(parse_array(0.9, nodes, phases))
-    starbus["vmax"] = PMs.MultiPhaseVector(parse_array(1.1, nodes, phases))
+    starbus["vmin"] = PMs.MultiConductorVector(parse_array(0.9, nodes, phases))
+    starbus["vmax"] = PMs.MultiConductorVector(parse_array(1.1, nodes, phases))
     starbus["name"] = "$(transformer["name"]) starbus"
-    starbus["vm"] = PMs.MultiPhaseVector(parse_array(1.0, nodes, phases))
-    starbus["va"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, phases))
+    starbus["vm"] = PMs.MultiConductorVector(parse_array(1.0, nodes, phases))
+    starbus["va"] = PMs.MultiConductorVector(parse_array(0.0, nodes, phases))
     starbus["bus_type"] = 1
     starbus["index"] = starbus_id
 
@@ -106,11 +106,11 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
 
         busDict["bus_type"] = bus == "sourcebus" ? 3 : 1
 
-        busDict["vm"] = PMs.MultiPhaseVector(parse_array(vm, nodes, nphases))
-        busDict["va"] = PMs.MultiPhaseVector(parse_array([rad2deg(2*pi/nphases*(i-1))+ph1_ang for i in 1:nphases], nodes, nphases))
+        busDict["vm"] = PMs.MultiConductorVector(parse_array(vm, nodes, nphases))
+        busDict["va"] = PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nphases*(i-1))+ph1_ang for i in 1:nphases], nodes, nphases))
 
-        busDict["vmin"] = PMs.MultiPhaseVector(parse_array(vmi, nodes, nphases))
-        busDict["vmax"] = PMs.MultiPhaseVector(parse_array(vma, nodes, nphases))
+        busDict["vmin"] = PMs.MultiConductorVector(parse_array(vmi, nodes, nphases))
+        busDict["vmax"] = PMs.MultiConductorVector(parse_array(vma, nodes, nphases))
 
         busDict["base_kv"] = tppm_data["basekv"]
 
@@ -176,8 +176,8 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             loadDict["name"] = defaults["name"]
             loadDict["load_bus"] = find_bus(name, tppm_data)
-            loadDict["pd"] = PMs.MultiPhaseVector(parse_array(defaults["kw"] / 1e3, nodes, nphases))
-            loadDict["qd"] = PMs.MultiPhaseVector(parse_array(defaults["kvar"] / 1e3, nodes, nphases))
+            loadDict["pd"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nphases))
+            loadDict["qd"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nphases))
             loadDict["status"] = convert(Int, defaults["enabled"])
 
             loadDict["index"] = length(tppm_data["load"]) + 1
@@ -219,8 +219,8 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             shuntDict["shunt_bus"] = find_bus(name, tppm_data)
             shuntDict["name"] = defaults["name"]
-            shuntDict["gs"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))  # TODO:
-            shuntDict["bs"] = PMs.MultiPhaseVector(parse_array(Gcap, nodes, nphases))
+            shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))  # TODO:
+            shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nphases))
             shuntDict["status"] = convert(Int, defaults["enabled"])
             shuntDict["index"] = length(tppm_data["shunt"]) + 1
 
@@ -251,8 +251,8 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
                 shuntDict["shunt_bus"] = find_bus(name, tppm_data)
                 shuntDict["name"] = defaults["name"]
-                shuntDict["gs"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))  # TODO:
-                shuntDict["bs"] = PMs.MultiPhaseVector(parse_array(Gcap, nodes, nphases))
+                shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))  # TODO:
+                shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nphases))
                 shuntDict["status"] = convert(Int, defaults["enabled"])
 
                 shuntDict["index"] = length(tppm_data["shunt"]) + 1
@@ -291,14 +291,14 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
     genDict["gen_status"] = convert(Int, defaults["enabled"])
 
     # TODO: populate with VSOURCE properties
-    genDict["pg"] = PMs.MultiPhaseVector(parse_array( 0.0, nodes, nphases))
-    genDict["qg"] = PMs.MultiPhaseVector(parse_array( 0.0, nodes, nphases))
+    genDict["pg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nphases))
+    genDict["qg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nphases))
 
-    genDict["qmin"] = PMs.MultiPhaseVector(parse_array(-Inf, nodes, nphases))
-    genDict["qmax"] = PMs.MultiPhaseVector(parse_array( Inf, nodes, nphases))
+    genDict["qmin"] = PMs.MultiConductorVector(parse_array(-Inf, nodes, nphases))
+    genDict["qmax"] = PMs.MultiConductorVector(parse_array( Inf, nodes, nphases))
 
-    genDict["pmax"] = PMs.MultiPhaseVector(parse_array( Inf, nodes, nphases))
-    genDict["pmin"] = PMs.MultiPhaseVector(parse_array(-Inf, nodes, nphases))
+    genDict["pmax"] = PMs.MultiConductorVector(parse_array( Inf, nodes, nphases))
+    genDict["pmin"] = PMs.MultiConductorVector(parse_array(-Inf, nodes, nphases))
 
 
     genDict["model"] = 2
@@ -330,14 +330,14 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             genDict["gen_bus"] = find_bus(name, tppm_data)
             genDict["name"] = defaults["name"]
             genDict["gen_status"] = convert(Int, defaults["enabled"])
-            genDict["pg"] = PMs.MultiPhaseVector(parse_array(defaults["kw"] / (1e3 * nphases), nodes, nphases))
-            genDict["qg"] = PMs.MultiPhaseVector(parse_array(defaults["kvar"] / (1e3 * nphases), nodes, nphases))
-            genDict["vg"] = PMs.MultiPhaseVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nphases))
+            genDict["pg"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / (1e3 * nphases), nodes, nphases))
+            genDict["qg"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / (1e3 * nphases), nodes, nphases))
+            genDict["vg"] = PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nphases))
 
-            genDict["qmin"] = PMs.MultiPhaseVector(parse_array(defaults["minkvar"] / (1e3 * nphases), nodes, nphases))
-            genDict["qmax"] = PMs.MultiPhaseVector(parse_array(defaults["maxkvar"] / (1e3 * nphases), nodes, nphases))
+            genDict["qmin"] = PMs.MultiConductorVector(parse_array(defaults["minkvar"] / (1e3 * nphases), nodes, nphases))
+            genDict["qmax"] = PMs.MultiConductorVector(parse_array(defaults["maxkvar"] / (1e3 * nphases), nodes, nphases))
 
-            genDict["apf"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+            genDict["apf"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
             genDict["pmax"] = genDict["pg"]  # Assumes generator is at rated power
             genDict["pmin"] = 0.3 * genDict["pg"]  # 30% of pmax
@@ -353,7 +353,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             # and they are not supported in OpenDSS
             genDict["ramp_agc"] = genDict["pmax"]
 
-            genDict["ramp_q"] = PMs.MultiPhaseVector(parse_array(max.(abs.(genDict["qmin"].values), abs.(genDict["qmax"].values)), nodes, nphases))
+            genDict["ramp_q"] = PMs.MultiConductorVector(parse_array(max.(abs.(genDict["qmin"].values), abs.(genDict["qmax"].values)), nodes, nphases))
             genDict["ramp_10"] = genDict["pmax"]
             genDict["ramp_30"] = genDict["pmax"]
 
@@ -432,31 +432,31 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             cmatrix = parse_matrix(defaults["cmatrix"], nodes, nphases)
             Zbase = (tppm_data["basekv"] / sqrt(3))^2 * nphases / (tppm_data["baseMVA"])
 
-            branchDict["br_r"] = PMs.MultiPhaseMatrix(rmatrix * defaults["length"] / Zbase)
-            branchDict["br_x"] = PMs.MultiPhaseMatrix(xmatrix * defaults["length"] / Zbase)
+            branchDict["br_r"] = PMs.MultiConductorMatrix(rmatrix * defaults["length"] / Zbase)
+            branchDict["br_x"] = PMs.MultiConductorMatrix(xmatrix * defaults["length"] / Zbase)
 
             # CHECK: Do we need to reformulate to use a matrix instead of a vector for g, b?
-            branchDict["g_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-            branchDict["g_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+            branchDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+            branchDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
             if !isdiag(cmatrix)
                 info(LOGGER, "Only diagonal elements of cmatrix are used to obtain branch values `b_fr/to`")
             end
-            branchDict["b_fr"] = PMs.MultiPhaseVector(diag(Zbase * (2.0 * pi * defaults["freq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
-            branchDict["b_to"] = PMs.MultiPhaseVector(diag(Zbase * (2.0 * pi * defaults["freq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
+            branchDict["b_fr"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["freq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
+            branchDict["b_to"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["freq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
 
             # TODO: pick a better value for emergamps
-            branchDict["rate_a"] = PMs.MultiPhaseVector(parse_array(defaults["normamps"], nodes, nphases, NaN))
-            branchDict["rate_b"] = PMs.MultiPhaseVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
-            branchDict["rate_c"] = PMs.MultiPhaseVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
+            branchDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nphases, NaN))
+            branchDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
+            branchDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
 
-            branchDict["tap"] = PMs.MultiPhaseVector(parse_array(1.0, nodes, nphases, 1.0))
-            branchDict["shift"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+            branchDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nphases, 1.0))
+            branchDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
             branchDict["br_status"] = convert(Int, defaults["enabled"])
 
-            branchDict["angmin"] = PMs.MultiPhaseVector(parse_array(-60.0, nodes, nphases, -60.0))
-            branchDict["angmax"] = PMs.MultiPhaseVector(parse_array( 60.0, nodes, nphases,  60.0))
+            branchDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
+            branchDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
 
             branchDict["transformer"] = false
 
@@ -503,26 +503,26 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
                 transDict["f_bus"] = find_bus(f_bus, tppm_data)
                 transDict["t_bus"] = find_bus(t_bus, tppm_data)
 
-                transDict["br_r"] = PMs.MultiPhaseMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
-                transDict["br_x"] = PMs.MultiPhaseMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
+                transDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
+                transDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
 
-                transDict["g_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                transDict["g_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                transDict["b_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                transDict["b_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+                transDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                transDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                transDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                transDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
                 # CHECK: unit conversion?
-                transDict["rate_a"] = PMs.MultiPhaseVector(parse_array(defaults["normhkva"], nodes, nphases, NaN))
-                transDict["rate_b"] = PMs.MultiPhaseVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
-                transDict["rate_c"] = PMs.MultiPhaseVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
+                transDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normhkva"], nodes, nphases, NaN))
+                transDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
+                transDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
 
-                transDict["tap"] = PMs.MultiPhaseVector(parse_array(/(defaults["taps"]...), nodes, nphases, 1.0))
-                transDict["shift"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+                transDict["tap"] = PMs.MultiConductorVector(parse_array(/(defaults["taps"]...), nodes, nphases, 1.0))
+                transDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
                 transDict["br_status"] = convert(Int, defaults["enabled"])
 
-                transDict["angmin"] = PMs.MultiPhaseVector(parse_array(-60.0, nodes, nphases, -60.0))
-                transDict["angmax"] = PMs.MultiPhaseVector(parse_array( 60.0, nodes, nphases,  60.0))
+                transDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
+                transDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
 
                 transDict["transformer"] = true
 
@@ -550,26 +550,26 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
 
                     transDict["name"] = "$(defaults["name"]) winding $m"
 
-                    transDict["br_r"] = PMs.MultiPhaseMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
-                    transDict["br_x"] = PMs.MultiPhaseMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
+                    transDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
+                    transDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
 
-                    transDict["g_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                    transDict["g_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                    transDict["b_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                    transDict["b_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+                    transDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                    transDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                    transDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                    transDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
                     # CHECK: unit conversion?
-                    transDict["rate_a"] = PMs.MultiPhaseVector(parse_array(defaults["normhkva"], nodes, nphases, NaN))
-                    transDict["rate_b"] = PMs.MultiPhaseVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
-                    transDict["rate_c"] = PMs.MultiPhaseVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
+                    transDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normhkva"], nodes, nphases, NaN))
+                    transDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
+                    transDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
 
-                    transDict["tap"] = PMs.MultiPhaseVector(parse_array(defaults["taps"][m], nodes, nphases, 1.0))
-                    transDict["shift"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+                    transDict["tap"] = PMs.MultiConductorVector(parse_array(defaults["taps"][m], nodes, nphases, 1.0))
+                    transDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
                     transDict["br_status"] = convert(Int, defaults["enabled"])
 
-                    transDict["angmin"] = PMs.MultiPhaseVector(parse_array(-60.0, nodes, nphases, -60.0))
-                    transDict["angmax"] = PMs.MultiPhaseVector(parse_array( 60.0, nodes, nphases,  60.0))
+                    transDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
+                    transDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
 
                     transDict["transformer"] = true
 
@@ -605,25 +605,25 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
                 reactDict["f_bus"] = find_bus(f_bus, tppm_data)
                 reactDict["t_bus"] = find_bus(t_bus, tppm_data)
 
-                reactDict["br_r"] = PMs.MultiPhaseMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
-                reactDict["br_x"] = PMs.MultiPhaseMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
+                reactDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
+                reactDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
 
-                reactDict["g_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                reactDict["g_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                reactDict["b_fr"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
-                reactDict["b_to"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+                reactDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                reactDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                reactDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                reactDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
-                reactDict["rate_a"] = PMs.MultiPhaseVector(parse_array(defaults["normamps"], nodes, nphases, NaN))
-                reactDict["rate_b"] = PMs.MultiPhaseVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
-                reactDict["rate_c"] = PMs.MultiPhaseVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
+                reactDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nphases, NaN))
+                reactDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
+                reactDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
 
-                reactDict["tap"] = PMs.MultiPhaseVector(parse_array(1.0, nodes, nphases, NaN))
-                reactDict["shift"] = PMs.MultiPhaseVector(parse_array(0.0, nodes, nphases))
+                reactDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nphases, NaN))
+                reactDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
 
                 reactDict["br_status"] = convert(Int, defaults["enabled"])
 
-                reactDict["angmin"] = PMs.MultiPhaseVector(parse_array(-60.0, nodes, nphases, -60.0))
-                reactDict["angmax"] = PMs.MultiPhaseVector(parse_array( 60.0, nodes, nphases,  60.0))
+                reactDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
+                reactDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
 
                 reactDict["transformer"] = true
 

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -20,7 +20,7 @@ function create_starbus(tppm_data::Dict, transformer::Dict)::Dict
 
     base = convert(Int, 10^ceil(log10(abs(PMs.find_max_bus_id(tppm_data)))))
     name, nodes = parse_busname(transformer["buses"][1])
-    phases = tppm_data["phases"]
+    phases = tppm_data["conductors"]
     starbus_id = find_bus(name, tppm_data) + base
 
     starbus["bus_i"] = starbus_id
@@ -94,7 +94,7 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
     for (n, (bus, nodes)) in enumerate(buses)
         busDict = Dict{String,Any}()
 
-        nphases = tppm_data["phases"]
+        nconductors = tppm_data["conductors"]
         ph1_ang = bus == "sourcebus" ? circuit["angle"] : 0.0
         vm = bus == "sourcebus" ? circuit["pu"] : 1.0
         vmi = bus == "sourcebus" ? circuit["pu"] - circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"]) : vmin
@@ -106,11 +106,11 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
 
         busDict["bus_type"] = bus == "sourcebus" ? 3 : 1
 
-        busDict["vm"] = PMs.MultiConductorVector(parse_array(vm, nodes, nphases))
-        busDict["va"] = PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nphases*(i-1))+ph1_ang for i in 1:nphases], nodes, nphases))
+        busDict["vm"] = PMs.MultiConductorVector(parse_array(vm, nodes, nconductors))
+        busDict["va"] = PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nconductors*(i-1))+ph1_ang for i in 1:nconductors], nodes, nconductors))
 
-        busDict["vmin"] = PMs.MultiConductorVector(parse_array(vmi, nodes, nphases))
-        busDict["vmax"] = PMs.MultiConductorVector(parse_array(vma, nodes, nphases))
+        busDict["vmin"] = PMs.MultiConductorVector(parse_array(vmi, nodes, nconductors))
+        busDict["vmax"] = PMs.MultiConductorVector(parse_array(vma, nodes, nconductors))
 
         busDict["base_kv"] = tppm_data["basekv"]
 
@@ -171,13 +171,13 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             loadDict = Dict{String,Any}()
 
-            nphases = tppm_data["phases"]
+            nconductors = tppm_data["conductors"]
             name, nodes = parse_busname(defaults["bus1"])
 
             loadDict["name"] = defaults["name"]
             loadDict["load_bus"] = find_bus(name, tppm_data)
-            loadDict["pd"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nphases))
-            loadDict["qd"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nphases))
+            loadDict["pd"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nconductors))
+            loadDict["qd"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nconductors))
             loadDict["status"] = convert(Int, defaults["enabled"])
 
             loadDict["index"] = length(tppm_data["load"]) + 1
@@ -211,16 +211,16 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             shuntDict = Dict{String,Any}()
 
-            nphases = tppm_data["phases"]
+            nconductors = tppm_data["conductors"]
             name, nodes = parse_busname(defaults["bus1"])
 
-            Zbase = (tppm_data["basekv"] / sqrt(3.0))^2 * nphases / tppm_data["baseMVA"]  # Use single-phase base impedance for each phase
-            Gcap = -Zbase * sum(defaults["kvar"]) / (nphases * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
+            Zbase = (tppm_data["basekv"] / sqrt(3.0))^2 * nconductors / tppm_data["baseMVA"]  # Use single-phase base impedance for each phase
+            Gcap = -Zbase * sum(defaults["kvar"]) / (nconductors * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
 
             shuntDict["shunt_bus"] = find_bus(name, tppm_data)
             shuntDict["name"] = defaults["name"]
-            shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))  # TODO:
-            shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nphases))
+            shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:
+            shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nconductors))
             shuntDict["status"] = convert(Int, defaults["enabled"])
             shuntDict["index"] = length(tppm_data["shunt"]) + 1
 
@@ -243,16 +243,16 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
                 shuntDict = Dict{String,Any}()
 
-                nphases = tppm_data["phases"]
+                nconductors = tppm_data["conductors"]
                 name, nodes = parse_busname(defaults["bus1"])
 
-                Zbase = (tppm_data["basekv"] / sqrt(3.0))^2 * nphases / tppm_data["baseMVA"]  # Use single-phase base impedance for each phase
-                Gcap = Zbase * sum(defaults["kvar"]) / (nphases * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
+                Zbase = (tppm_data["basekv"] / sqrt(3.0))^2 * nconductors / tppm_data["baseMVA"]  # Use single-phase base impedance for each phase
+                Gcap = Zbase * sum(defaults["kvar"]) / (nconductors * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
 
                 shuntDict["shunt_bus"] = find_bus(name, tppm_data)
                 shuntDict["name"] = defaults["name"]
-                shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))  # TODO:
-                shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nphases))
+                shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:
+                shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nconductors))
                 shuntDict["status"] = convert(Int, defaults["enabled"])
 
                 shuntDict["index"] = length(tppm_data["shunt"]) + 1
@@ -283,7 +283,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
     genDict = Dict{String,Any}()
 
-    nphases = tppm_data["phases"]
+    nconductors = tppm_data["conductors"]
     name, nodes = parse_busname(defaults["bus1"])
 
     genDict["gen_bus"] = find_bus(name, tppm_data)
@@ -291,14 +291,14 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
     genDict["gen_status"] = convert(Int, defaults["enabled"])
 
     # TODO: populate with VSOURCE properties
-    genDict["pg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nphases))
-    genDict["qg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nphases))
+    genDict["pg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nconductors))
+    genDict["qg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nconductors))
 
-    genDict["qmin"] = PMs.MultiConductorVector(parse_array(-Inf, nodes, nphases))
-    genDict["qmax"] = PMs.MultiConductorVector(parse_array( Inf, nodes, nphases))
+    genDict["qmin"] = PMs.MultiConductorVector(parse_array(-Inf, nodes, nconductors))
+    genDict["qmax"] = PMs.MultiConductorVector(parse_array( Inf, nodes, nconductors))
 
-    genDict["pmax"] = PMs.MultiConductorVector(parse_array( Inf, nodes, nphases))
-    genDict["pmin"] = PMs.MultiConductorVector(parse_array(-Inf, nodes, nphases))
+    genDict["pmax"] = PMs.MultiConductorVector(parse_array( Inf, nodes, nconductors))
+    genDict["pmin"] = PMs.MultiConductorVector(parse_array(-Inf, nodes, nconductors))
 
 
     genDict["model"] = 2
@@ -324,20 +324,20 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             genDict = Dict{String,Any}()
 
-            nphases = tppm_data["phases"]
+            nconductors = tppm_data["conductors"]
             name, nodes = parse_busname(defaults["bus1"])
 
             genDict["gen_bus"] = find_bus(name, tppm_data)
             genDict["name"] = defaults["name"]
             genDict["gen_status"] = convert(Int, defaults["enabled"])
-            genDict["pg"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / (1e3 * nphases), nodes, nphases))
-            genDict["qg"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / (1e3 * nphases), nodes, nphases))
-            genDict["vg"] = PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nphases))
+            genDict["pg"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["qg"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["vg"] = PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nconductors))
 
-            genDict["qmin"] = PMs.MultiConductorVector(parse_array(defaults["minkvar"] / (1e3 * nphases), nodes, nphases))
-            genDict["qmax"] = PMs.MultiConductorVector(parse_array(defaults["maxkvar"] / (1e3 * nphases), nodes, nphases))
+            genDict["qmin"] = PMs.MultiConductorVector(parse_array(defaults["minkvar"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["qmax"] = PMs.MultiConductorVector(parse_array(defaults["maxkvar"] / (1e3 * nconductors), nodes, nconductors))
 
-            genDict["apf"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+            genDict["apf"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             genDict["pmax"] = genDict["pg"]  # Assumes generator is at rated power
             genDict["pmin"] = 0.3 * genDict["pg"]  # 30% of pmax
@@ -353,7 +353,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             # and they are not supported in OpenDSS
             genDict["ramp_agc"] = genDict["pmax"]
 
-            genDict["ramp_q"] = PMs.MultiConductorVector(parse_array(max.(abs.(genDict["qmin"].values), abs.(genDict["qmax"].values)), nodes, nphases))
+            genDict["ramp_q"] = PMs.MultiConductorVector(parse_array(max.(abs.(genDict["qmin"].values), abs.(genDict["qmax"].values)), nodes, nconductors))
             genDict["ramp_10"] = genDict["pmax"]
             genDict["ramp_30"] = genDict["pmax"]
 
@@ -418,7 +418,7 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             branchDict = Dict{String,Any}()
 
-            nphases = tppm_data["phases"]
+            nconductors = tppm_data["conductors"]
 
             branchDict["name"] = defaults["name"]
 
@@ -427,17 +427,17 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             branchDict["length"] = defaults["length"]
 
-            rmatrix = parse_matrix(defaults["rmatrix"], nodes, nphases) * 3  # why?
-            xmatrix = parse_matrix(defaults["xmatrix"], nodes, nphases) * 3  # why?
-            cmatrix = parse_matrix(defaults["cmatrix"], nodes, nphases)
-            Zbase = (tppm_data["basekv"] / sqrt(3))^2 * nphases / (tppm_data["baseMVA"])
+            rmatrix = parse_matrix(defaults["rmatrix"], nodes, nconductors) * 3  # why?
+            xmatrix = parse_matrix(defaults["xmatrix"], nodes, nconductors) * 3  # why?
+            cmatrix = parse_matrix(defaults["cmatrix"], nodes, nconductors)
+            Zbase = (tppm_data["basekv"] / sqrt(3))^2 * nconductors / (tppm_data["baseMVA"])
 
             branchDict["br_r"] = PMs.MultiConductorMatrix(rmatrix * defaults["length"] / Zbase)
             branchDict["br_x"] = PMs.MultiConductorMatrix(xmatrix * defaults["length"] / Zbase)
 
             # CHECK: Do we need to reformulate to use a matrix instead of a vector for g, b?
-            branchDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-            branchDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+            branchDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            branchDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             if !isdiag(cmatrix)
                 info(LOGGER, "Only diagonal elements of cmatrix are used to obtain branch values `b_fr/to`")
@@ -446,17 +446,17 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             branchDict["b_to"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["freq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
 
             # TODO: pick a better value for emergamps
-            branchDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nphases, NaN))
-            branchDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
-            branchDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
+            branchDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nconductors, NaN))
+            branchDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors, NaN))
+            branchDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors, NaN))
 
-            branchDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nphases, 1.0))
-            branchDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+            branchDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors, 1.0))
+            branchDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             branchDict["br_status"] = convert(Int, defaults["enabled"])
 
-            branchDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
-            branchDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
+            branchDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
+            branchDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
 
             branchDict["transformer"] = false
 
@@ -490,7 +490,7 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
 
             defaults = createTransformer(transformer["name"]; to_sym_keys(transformer)...)
 
-            nphases = tppm_data["phases"]
+            nconductors = tppm_data["conductors"]
             windings = defaults["windings"]
 
             if windings == 2
@@ -503,26 +503,26 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
                 transDict["f_bus"] = find_bus(f_bus, tppm_data)
                 transDict["t_bus"] = find_bus(t_bus, tppm_data)
 
-                transDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
-                transDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
+                transDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nconductors)), nodes, nconductors))
+                transDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nconductors, nconductors), nodes, nconductors))
 
-                transDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                transDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                transDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                transDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                transDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                transDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                transDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                transDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
                 # CHECK: unit conversion?
-                transDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normhkva"], nodes, nphases, NaN))
-                transDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
-                transDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
+                transDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normhkva"], nodes, nconductors, NaN))
+                transDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nconductors, NaN))
+                transDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nconductors, NaN))
 
-                transDict["tap"] = PMs.MultiConductorVector(parse_array(/(defaults["taps"]...), nodes, nphases, 1.0))
-                transDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                transDict["tap"] = PMs.MultiConductorVector(parse_array(/(defaults["taps"]...), nodes, nconductors, 1.0))
+                transDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
                 transDict["br_status"] = convert(Int, defaults["enabled"])
 
-                transDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
-                transDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
+                transDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
+                transDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
 
                 transDict["transformer"] = true
 
@@ -550,26 +550,26 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
 
                     transDict["name"] = "$(defaults["name"]) winding $m"
 
-                    transDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
-                    transDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
+                    transDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nconductors)), nodes, nconductors))
+                    transDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nconductors, nconductors), nodes, nconductors))
 
-                    transDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                    transDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                    transDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                    transDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                    transDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                    transDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                    transDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                    transDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
                     # CHECK: unit conversion?
-                    transDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normhkva"], nodes, nphases, NaN))
-                    transDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
-                    transDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nphases, NaN))
+                    transDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normhkva"], nodes, nconductors, NaN))
+                    transDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nconductors, NaN))
+                    transDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emerghkva"], nodes, nconductors, NaN))
 
-                    transDict["tap"] = PMs.MultiConductorVector(parse_array(defaults["taps"][m], nodes, nphases, 1.0))
-                    transDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                    transDict["tap"] = PMs.MultiConductorVector(parse_array(defaults["taps"][m], nodes, nconductors, 1.0))
+                    transDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
                     transDict["br_status"] = convert(Int, defaults["enabled"])
 
-                    transDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
-                    transDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
+                    transDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
+                    transDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
 
                     transDict["transformer"] = true
 
@@ -596,7 +596,7 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
 
                 reactDict = Dict{String,Any}()
 
-                nphases = tppm_data["phases"]
+                nconductors = tppm_data["conductors"]
 
                 f_bus, nodes = parse_busname(defaults["bus1"])
                 t_bus = parse_busname(defaults["bus2"])[1]
@@ -605,25 +605,25 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
                 reactDict["f_bus"] = find_bus(f_bus, tppm_data)
                 reactDict["t_bus"] = find_bus(t_bus, tppm_data)
 
-                reactDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nphases)), nodes, nphases))
-                reactDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nphases, nphases), nodes, nphases))
+                reactDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(fill(0.2, nconductors)), nodes, nconductors))
+                reactDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nconductors, nconductors), nodes, nconductors))
 
-                reactDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                reactDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                reactDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
-                reactDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                reactDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
-                reactDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nphases, NaN))
-                reactDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
-                reactDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nphases, NaN))
+                reactDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nconductors, NaN))
+                reactDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors, NaN))
+                reactDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors, NaN))
 
-                reactDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nphases, NaN))
-                reactDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nphases))
+                reactDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors, NaN))
+                reactDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
                 reactDict["br_status"] = convert(Int, defaults["enabled"])
 
-                reactDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nphases, -60.0))
-                reactDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nphases,  60.0))
+                reactDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
+                reactDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
 
                 reactDict["transformer"] = true
 
@@ -728,7 +728,7 @@ function parse_opendss(dss_data::Dict; import_all::Bool=false, vmin::Float64=0.9
         tppm_data["baseMVA"] = defaults["basemva"]
         tppm_data["basefreq"] = defaults["basefreq"]
         tppm_data["pu"] = defaults["pu"]
-        tppm_data["phases"] = defaults["phases"]
+        tppm_data["conductors"] = defaults["phases"]
     else
         error(LOGGER, "Circuit not defined, not a valid circuit!")
     end

--- a/src/prob/tp_opf.jl
+++ b/src/prob/tp_opf.jl
@@ -2,55 +2,55 @@ export run_tp_opf, run_ac_tp_opf
 
 ""
 function run_ac_tp_opf(file, solver; kwargs...)
-    return run_tp_opf(file, PMs.ACPPowerModel, solver; multiphase=true, kwargs...)
+    return run_tp_opf(file, PMs.ACPPowerModel, solver; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiphase=true, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiphase=true, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function post_tp_opf(pm::GenericPowerModel)
-    for h in PMs.phase_ids(pm)
-        variable_tp_voltage(pm, ph=h)
-        PMs.variable_generation(pm, ph=h)
-        PMs.variable_branch_flow(pm, ph=h)
-        PMs.variable_dcline_flow(pm, ph=h)
+    for c in PMs.conductor_ids(pm)
+        variable_tp_voltage(pm, cnd=c)
+        PMs.variable_generation(pm, cnd=c)
+        PMs.variable_branch_flow(pm, cnd=c)
+        PMs.variable_dcline_flow(pm, cnd=c)
     end
 
-    for h in PMs.phase_ids(pm)
-        constraint_tp_voltage(pm, ph=h)
+    for c in PMs.conductor_ids(pm)
+        constraint_tp_voltage(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
-            constraint_tp_theta_ref(pm, i, ph=h)
+            constraint_tp_theta_ref(pm, i, cnd=c)
         end
 
         for i in ids(pm, :bus)
-            PMs.constraint_kcl_shunt(pm, i, ph=h)
+            PMs.constraint_kcl_shunt(pm, i, cnd=c)
         end
 
         for i in ids(pm, :branch)
-            constraint_ohms_tp_yt_from(pm, i, ph=h)
-            constraint_ohms_tp_yt_to(pm, i, ph=h)
+            constraint_ohms_tp_yt_from(pm, i, cnd=c)
+            constraint_ohms_tp_yt_to(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference(pm, i, ph=h)
+            PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, ph=h)
-            PMs.constraint_thermal_limit_to(pm, i, ph=h)
+            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
 
         for i in ids(pm, :dcline)
-            PMs.constraint_dcline(pm, i, ph=h)
+            PMs.constraint_dcline(pm, i, cnd=c)
         end
     end
 

--- a/src/prob/tp_opf_bf.jl
+++ b/src/prob/tp_opf_bf.jl
@@ -5,7 +5,7 @@ function run_tp_opf_bf(data::Dict{String,Any}, model_constructor, solver; kwargs
     if model_constructor != PMs.SOCBFPowerModel
         error(LOGGER, "The problem type opf_bf at the moment only supports the SOCBFForm formulation")
     end
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_bf; multiphase=true, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_bf; multiconductor=true, kwargs...)
 end
 
 
@@ -15,44 +15,44 @@ function run_tp_opf_bf(file::String, model_constructor, solver; kwargs...)
         error(LOGGER, "The problem type opf_bf at the moment only supports the SOCBFForm formulation")
     end
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_bf; multiphase=true, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_bf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function post_tp_opf_bf(pm::GenericPowerModel)
-    for h in PMs.phase_ids(pm)
-        variable_tp_voltage(pm, ph=h)
-        PMs.variable_generation(pm, ph=h)
-        PMs.variable_branch_flow(pm, ph=h)
-        PMs.variable_branch_current(pm, ph=h)
-        PMs.variable_dcline_flow(pm, ph=h)
+    for c in PMs.conductor_ids(pm)
+        variable_tp_voltage(pm, cnd=c)
+        PMs.variable_generation(pm, cnd=c)
+        PMs.variable_branch_flow(pm, cnd=c)
+        PMs.variable_branch_current(pm, cnd=c)
+        PMs.variable_dcline_flow(pm, cnd=c)
     end
 
-    for h in PMs.phase_ids(pm)
+    for c in PMs.conductor_ids(pm)
         for i in ids(pm, :ref_buses)
-            constraint_tp_theta_ref(pm, i, ph=h)
+            constraint_tp_theta_ref(pm, i, cnd=c)
         end
 
         for i in ids(pm, :bus)
-            PMs.constraint_kcl_shunt(pm, i, ph=h)
+            PMs.constraint_kcl_shunt(pm, i, cnd=c)
         end
 
         for i in ids(pm, :branch)
-            PMs.constraint_flow_losses(pm, i, ph=h)
+            PMs.constraint_flow_losses(pm, i, cnd=c)
 
-            constraint_tp_voltage_magnitude_difference(pm, i, ph=h)
+            constraint_tp_voltage_magnitude_difference(pm, i, cnd=c)
 
-            PMs.constraint_branch_current(pm, i, ph=h)
+            PMs.constraint_branch_current(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference(pm, i, ph=h)
+            PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, ph=h)
-            PMs.constraint_thermal_limit_to(pm, i, ph=h)
+            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
 
         for i in ids(pm, :dcline)
-            PMs.constraint_dcline(pm, i, ph=h)
+            PMs.constraint_dcline(pm, i, cnd=c)
         end
     end
 

--- a/src/prob/tp_ots.jl
+++ b/src/prob/tp_ots.jl
@@ -2,50 +2,50 @@ export run_tp_ots
 
 ""
 function run_tp_ots(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_ots; multiphase=true, solution_builder=PMs.get_ots_solution, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
 end
 
 
 ""
 function run_tp_ots(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_ots; multiphase=true, solution_builder=PMs.get_ots_solution, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
 end
 
 
 ""
 function post_tp_ots(pm::GenericPowerModel)
-    for h in PMs.phase_ids(pm)
-        PMs.variable_branch_indicator(pm, ph=h)
-        PMs.variable_voltage_on_off(pm, ph=h)
-        PMs.variable_generation(pm, ph=h)
-        PMs.variable_branch_flow(pm, ph=h)
-        PMs.variable_dcline_flow(pm, ph=h)
+    for c in PMs.conductor_ids(pm)
+        PMs.variable_branch_indicator(pm, cnd=c)
+        PMs.variable_voltage_on_off(pm, cnd=c)
+        PMs.variable_generation(pm, cnd=c)
+        PMs.variable_branch_flow(pm, cnd=c)
+        PMs.variable_dcline_flow(pm, cnd=c)
     end
 
-    for h in PMs.phase_ids(pm)
-        PMs.constraint_voltage_on_off(pm, ph=h)
+    for c in PMs.conductor_ids(pm)
+        PMs.constraint_voltage_on_off(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
-            constraint_tp_theta_ref(pm, i, ph=h)
+            constraint_tp_theta_ref(pm, i, cnd=c)
         end
 
         for i in ids(pm, :bus)
-            PMs.constraint_kcl_shunt(pm, i, ph=h)
+            PMs.constraint_kcl_shunt(pm, i, cnd=c)
         end
 
         for i in ids(pm, :branch)
-            constraint_ohms_tp_yt_from_on_off(pm, i, ph=h)
-            constraint_ohms_tp_yt_to_on_off(pm, i, ph=h)
+            constraint_ohms_tp_yt_from_on_off(pm, i, cnd=c)
+            constraint_ohms_tp_yt_to_on_off(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference_on_off(pm, i, ph=h)
+            PMs.constraint_voltage_angle_difference_on_off(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from_on_off(pm, i, ph=h)
-            PMs.constraint_thermal_limit_to_on_off(pm, i, ph=h)
+            PMs.constraint_thermal_limit_from_on_off(pm, i, cnd=c)
+            PMs.constraint_thermal_limit_to_on_off(pm, i, cnd=c)
         end
 
         for i in ids(pm, :dcline)
-            PMs.constraint_dcline(pm, i, ph=h)
+            PMs.constraint_dcline(pm, i, cnd=c)
         end
     end
 

--- a/src/prob/tp_pf.jl
+++ b/src/prob/tp_pf.jl
@@ -15,71 +15,71 @@ end
 
 ""
 function run_tp_pf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf; multiphase=true, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_pf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf; multiphase=true, kwargs...)
+    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function post_tp_pf(pm::GenericPowerModel)
-    for h in PMs.phase_ids(pm)
-        variable_tp_voltage(pm, bounded=false, ph=h)
-        # PMs.variable_voltage(pm, bounded=false, ph=h)
-        PMs.variable_generation(pm, bounded=false, ph=h)
-        PMs.variable_branch_flow(pm, bounded=false, ph=h)
-        PMs.variable_dcline_flow(pm, bounded=false, ph=h)
+    for c in PMs.conductor_ids(pm)
+        variable_tp_voltage(pm, bounded=false, cnd=c)
+        # PMs.variable_voltage(pm, bounded=false, cnd=c)
+        PMs.variable_generation(pm, bounded=false, cnd=c)
+        PMs.variable_branch_flow(pm, bounded=false, cnd=c)
+        PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
-    for h in PMs.phase_ids(pm)
-        constraint_tp_voltage(pm, ph=h)
-        # PMs.constraint_voltage(pm, ph=h)
+    for c in PMs.conductor_ids(pm)
+        constraint_tp_voltage(pm, cnd=c)
+        # PMs.constraint_voltage(pm, cnd=c)
 
         for (i,bus) in ref(pm, :ref_buses)
             @assert bus["bus_type"] == 3
-            constraint_tp_theta_ref(pm, i, ph=h)
-            # PMs.constraint_theta_ref(pm, i, ph=h)
-            PMs.constraint_voltage_magnitude_setpoint(pm, i, ph=h)
+            constraint_tp_theta_ref(pm, i, cnd=c)
+            # PMs.constraint_theta_ref(pm, i, cnd=c)
+            PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
         end
 
         for (i,bus) in ref(pm, :bus)
-            PMs.constraint_kcl_shunt(pm, i, ph=h)
+            PMs.constraint_kcl_shunt(pm, i, cnd=c)
 
             # PV Bus Constraints
             if length(ref(pm, :bus_gens, i)) > 0 && !(i in ids(pm,:ref_buses))
                 # this assumes inactive generators are filtered out of bus_gens
                 @assert bus["bus_type"] == 2
 
-                PMs.constraint_voltage_magnitude_setpoint(pm, i, ph=h)
+                PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
                 for j in ref(pm, :bus_gens, i)
-                    PMs.constraint_active_gen_setpoint(pm, j, ph=h)
+                    PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
                 end
             end
         end
 
         for i in ids(pm, :branch)
-            constraint_ohms_tp_yt_from(pm, i, ph=h)
-            constraint_ohms_tp_yt_to(pm, i, ph=h)
-            # PMs.constraint_ohms_yt_from(pm, i, ph=h)
-            # PMs.constraint_ohms_yt_to(pm, i, ph=h)
+            constraint_ohms_tp_yt_from(pm, i, cnd=c)
+            constraint_ohms_tp_yt_to(pm, i, cnd=c)
+            # PMs.constraint_ohms_yt_from(pm, i, cnd=c)
+            # PMs.constraint_ohms_yt_to(pm, i, cnd=c)
         end
 
         for (i,dcline) in ref(pm, :dcline)
-            PMs.constraint_active_dcline_setpoint(pm, i, ph=h)
+            PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
 
             f_bus = ref(pm, :bus)[dcline["f_bus"]]
             if f_bus["bus_type"] == 1
-                PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], ph=h)
+                PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
             end
 
             t_bus = ref(pm, :bus)[dcline["t_bus"]]
             if t_bus["bus_type"] == 1
-                PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], ph=h)
+                PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
             end
         end
 

--- a/test/data/matlab/case5.m
+++ b/test/data/matlab/case5.m
@@ -1,6 +1,6 @@
 % NESTA v0.6.0, transformers removed
 % used in tests of,
-% - three phase creation with make_multiphase
+% - three phase creation with make_multiconductor
 
 function mpc = nesta_case5_pjm
 mpc.version = '2';

--- a/test/matlab.jl
+++ b/test/matlab.jl
@@ -12,11 +12,11 @@ TESTLOG = getlogger(PowerModels)
         @test length(data["gen"]) == 5
         @test length(data["branch"]) == 4
 
-        @test isa(data["bus"]["1"]["vm"], PMs.MultiPhaseVector{Float64})
-        @test isa(data["load"]["1"]["pd"], PMs.MultiPhaseVector{Float64})
-        @test isa(data["gen"]["1"]["pg"], PMs.MultiPhaseVector{Float64})
-        @test isa(data["branch"]["1"]["b_fr"], PMs.MultiPhaseVector{Float64})
-        @test isa(data["branch"]["1"]["br_x"], PMs.MultiPhaseMatrix{Float64})
+        @test isa(data["bus"]["1"]["vm"], PMs.MultiConductorVector{Float64})
+        @test isa(data["load"]["1"]["pd"], PMs.MultiConductorVector{Float64})
+        @test isa(data["gen"]["1"]["pg"], PMs.MultiConductorVector{Float64})
+        @test isa(data["branch"]["1"]["b_fr"], PMs.MultiConductorVector{Float64})
+        @test isa(data["branch"]["1"]["br_x"], PMs.MultiConductorMatrix{Float64})
 
         @test haskey(data["bus"]["1"], "bus_name")
     end
@@ -32,7 +32,7 @@ TESTLOG = getlogger(PowerModels)
         @test length(data["gen"]) == 5
         @test length(data["branch"]) == 4
 
-        @test isa(data["shunt"]["1"]["bs"], PMs.MultiPhaseVector{Float64})
+        @test isa(data["shunt"]["1"]["bs"], PMs.MultiConductorVector{Float64})
     end
 
     @testset "version warning" begin

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -1,5 +1,4 @@
 TESTLOG = getlogger(PowerModels)
-TPPMs = ThreePhasePowerModels
 
 @testset "opendss parser" begin
     @testset "reverse polish notation" begin
@@ -136,7 +135,7 @@ TPPMs = ThreePhasePowerModels
 
         for k in keys(tppm["gen"]["3"])
             if !(k in ["gen_bus", "index", "name"])
-                if isa(tppm["gen"]["3"][k], PMs.MultiPhaseValue)
+                if isa(tppm["gen"]["3"][k], PMs.MultiConductorValue)
                     @test all(isapprox.(tppm["gen"]["4"][k].values, tppm["gen"]["3"][k].values; atol=1e-12))
                 else
                     @test all(isapprox.(tppm["gen"]["4"][k], tppm["gen"]["3"][k]; atol=1e-12))
@@ -146,7 +145,7 @@ TPPMs = ThreePhasePowerModels
 
         for k in keys(tppm["branch"]["15"])
             if !(k in ["f_bus", "t_bus", "index", "name", "linecode"])
-                if isa(tppm["branch"]["15"][k], PMs.MultiPhaseValue)
+                if isa(tppm["branch"]["15"][k], PMs.MultiConductorValue)
                     @test all(isapprox.(tppm["branch"]["14"][k].values, tppm["branch"]["15"][k].values; atol=1e-12))
                     @test all(isapprox.(tppm["branch"]["12"][k].values, tppm["branch"]["13"][k].values; atol=1e-12))
                     @test all(isapprox.(tppm["branch"]["3"][k].values, tppm["branch"]["8"][k].values; atol=1e-12))
@@ -171,7 +170,7 @@ TPPMs = ThreePhasePowerModels
                 @test sol["status"] == :LocalOptimal
 
                 @test all(isapprox.(sol["solution"]["bus"]["2"]["vm"].values, 0.984377; atol=1e-4))
-                @test all(isapprox.(sol["solution"]["bus"]["2"]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) - deg2rad(0.79) for ph in 1:tppm["phases"]]; atol=deg2rad(0.2)))
+                @test all(isapprox.(sol["solution"]["bus"]["2"]["va"].values, [2 * pi / tppm["conductors"] * (c - 1) - deg2rad(0.79) for c in 1:tppm["conductors"]]; atol=deg2rad(0.2)))
 
                 @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018209; atol=1e-5)
                 @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.000208979; atol=1e-5)
@@ -188,7 +187,7 @@ TPPMs = ThreePhasePowerModels
                 @test sol["status"] == :LocalOptimal
 
                 for (bus, va, vm) in zip(["1", "2", "3"], [0.0, deg2rad(-0.08), deg2rad(-0.17)], [0.9959, 0.986559, 0.97572])
-                    @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) + va for ph in 1:tppm["phases"]]; atol=deg2rad(0.2)))
+                    @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["conductors"] * (c - 1) + va for c in 1:tppm["conductors"]]; atol=deg2rad(0.2)))
                     @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=1e-3))
                 end
 
@@ -221,7 +220,7 @@ TPPMs = ThreePhasePowerModels
                 for (bus, va, vm) in zip(["1", "2", "3"],
                                          [0.0, deg2rad.([-0.30, 0.09, -0.17]), deg2rad.([-0.65, 0.20, -0.36])],
                                          [0.9959, [0.980269, 0.986645, 0.989161], [0.962159, 0.975897, 0.981341]])
-                    @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) for ph in 1:tppm["phases"]] + va; atol=deg2rad(0.2)))
+                    @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["conductors"] * (c - 1) for c in 1:tppm["conductors"]] + va; atol=deg2rad(0.2)))
                     @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=2e-3))
                 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using ThreePhasePowerModels
+const TPPMs = ThreePhasePowerModels
+
 using Memento
 
 using PowerModels

--- a/test/tp_opf.jl
+++ b/test/tp_opf.jl
@@ -2,66 +2,66 @@
 @testset "test make multi-phase" begin
     @testset "3-bus 3-phase case" begin
         mp_data = PMs.parse_file("../../PowerModels/test/data/matpower/case3.m")
-        PMs.make_multiphase(mp_data, 3)
+        PMs.make_multiconductor(mp_data, 3)
         result = run_tp_opf(mp_data, PMs.ACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 47267.9; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph], 1.58067; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], 0.12669+2*pi/mp_data["phases"]*(ph-1); atol = 1e-3)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c], 1.58067; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], 0.12669+2*pi/mp_data["conductors"]*(c-1); atol = 1e-3)
         end
     end
     @testset "5-bus 5-phase ac case" begin
         mp_data = PMs.parse_file("../test/data/matlab/case5.m")
-        PMs.make_multiphase(mp_data, 3)
+        PMs.make_multiconductor(mp_data, 3)
         result = run_tp_opf(mp_data, PMs.ACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 45522.096; atol = 1e-1)
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph],  0.3999999; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], -0.0538204+2*pi/mp_data["phases"]*(ph-1); atol = 1e-5)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c],  0.3999999; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], -0.0538204+2*pi/mp_data["conductors"]*(c-1); atol = 1e-5)
         end
     end
 
     @testset "5-bus 5-phase soc case" begin
         mp_data = PMs.parse_file("../test/data/matlab/case5.m")
-        PMs.make_multiphase(mp_data, 3)
+        PMs.make_multiconductor(mp_data, 3)
         result = run_tp_opf(mp_data, PMs.SOCWRPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 45365.17; atol = 1e-1)
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph],  0.3999999; atol = 1e-3)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c],  0.3999999; atol = 1e-3)
         end
     end
 
     @testset "30-bus 3-phase ac case" begin
         mp_data = PMs.parse_file("../test/data/matlab/case30.m")
-        PMs.make_multiphase(mp_data, 3)
+        PMs.make_multiconductor(mp_data, 3)
         result = run_tp_opf(mp_data, PMs.ACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 614.007; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph],  2.192189; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], -0.071853+2*pi/mp_data["phases"]*(ph-1); atol = 1e-4)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c],  2.192189; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], -0.071853+2*pi/mp_data["conductors"]*(c-1); atol = 1e-4)
         end
     end
 
     @testset "30-bus 3-phase soc case" begin
         mp_data = PMs.parse_file("../test/data/matlab/case30.m")
-        PMs.make_multiphase(mp_data, 3)
+        PMs.make_multiconductor(mp_data, 3)
         result = run_tp_opf(mp_data, PMs.SOCWRPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 517.588; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph],  2.821313; atol = 1e-3)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c],  2.821313; atol = 1e-3)
         end
     end
 end
@@ -76,9 +76,9 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 55451.7; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["qg"][ph], 0.039742; atol = 1e-4)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], 0.048896+2*pi/mp_data["phases"]*(ph-1); atol = 1e-4)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["qg"][c], 0.039742; atol = 1e-4)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], 0.048896+2*pi/mp_data["conductors"]*(c-1); atol = 1e-4)
         end
     end
     @testset "5-bus independent radial different case" begin
@@ -91,9 +91,9 @@ end
         @test isapprox(result["solution"]["gen"]["1"]["qg"][1],  0.105276; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["2"]["va"][1],  0.0575114; atol = 1e-3)
 
-        for ph in 2:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["qg"][ph],  0.0897773; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph],  0.052544+2*pi/mp_data["phases"]*(ph-1); atol = 1e-3)
+        for c in 2:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["qg"][c],  0.0897773; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c],  0.052544+2*pi/mp_data["conductors"]*(c-1); atol = 1e-3)
         end
     end
     @testset "5-bus independent meshed different case" begin
@@ -103,9 +103,9 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 52964.4; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["qg"][ph],  0.3; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], -0.0135651+2*pi/mp_data["phases"]*(ph-1); atol = 1e-3)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["qg"][c],  0.3; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], -0.0135651+2*pi/mp_data["conductors"]*(c-1); atol = 1e-3)
         end
     end
     @testset "5-bus coupled meshed case" begin
@@ -119,8 +119,8 @@ end
             @test all(isapprox.(result["solution"]["gen"]["1"]["qg"].values, 0.3; atol = 1e-3))
 
             @test isapprox(result["solution"]["bus"]["2"]["va"][1], -0.0135573; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][2], -0.0123172+2*pi/mp_data["phases"]; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][3], -0.0136547+4*pi/mp_data["phases"]; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][2], -0.0123172+2*pi/mp_data["conductors"]; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][3], -0.0136547+4*pi/mp_data["conductors"]; atol = 1e-3)
         end
         @testset "soc case" begin
             mp_data = ThreePhasePowerModels.parse_file("../test/data/matlab/case5_c_m_a.m")
@@ -141,10 +141,10 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 55436.1; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph], 0.4; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["vm"][ph], 1.08564; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], 0.04905+2*pi/mp_data["phases"]*(ph-1); atol = 1e-3)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c], 0.4; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["vm"][c], 1.08564; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], 0.04905+2*pi/mp_data["conductors"]*(c-1); atol = 1e-3)
         end
     end
     @testset "5-bus coupled radial shunt case" begin
@@ -154,9 +154,9 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 56075.1; atol = 1e-1)
 
-        for ph in 1:mp_data["phases"]
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][ph],  0.4; atol = 1e-3)
-            @test isapprox(result["solution"]["bus"]["2"]["va"][ph], 0.055338+2*pi/mp_data["phases"]*(ph-1); atol = 5e-3)
+        for c in 1:mp_data["conductors"]
+            @test isapprox(result["solution"]["gen"]["1"]["pg"][c],  0.4; atol = 1e-3)
+            @test isapprox(result["solution"]["bus"]["2"]["va"][c], 0.055338+2*pi/mp_data["conductors"]*(c-1); atol = 5e-3)
         end
     end
 end

--- a/test/tp_opf_bf.jl
+++ b/test/tp_opf_bf.jl
@@ -1,7 +1,7 @@
 @testset "test soc distflow opf_bf" begin
     @testset "3-bus case" begin
         mp_data = PowerModels.parse_file("../../PowerModels/test/data/matpower/case3.m")
-        PowerModels.make_multiphase(mp_data, 3)
+        PowerModels.make_multiconductor(mp_data, 3)
         result = run_tp_opf_bf(mp_data, PMs.SOCBFPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
@@ -9,7 +9,7 @@
     end
     @testset "5-bus case" begin
         mp_data = PowerModels.parse_file("../test/data/matlab/case5.m")
-        PowerModels.make_multiphase(mp_data, 3)
+        PowerModels.make_multiconductor(mp_data, 3)
         result = run_tp_opf_bf(mp_data, PMs.SOCBFPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal

--- a/test/tp_ots.jl
+++ b/test/tp_ots.jl
@@ -1,7 +1,7 @@
 function check_br_status(sol)
     for (i,branch) in sol["branch"]
-        for ph in 1:length(branch["br_status"])
-            @test isapprox(branch["br_status"][ph], 0.0, rtol=1e-6) || isapprox(branch["br_status"][ph], 1.0, rtol=1e-6)
+        for c in 1:length(branch["br_status"])
+            @test isapprox(branch["br_status"][c], 0.0, rtol=1e-6) || isapprox(branch["br_status"][c], 1.0, rtol=1e-6)
         end
     end
 end
@@ -10,7 +10,7 @@ end
 @testset "test_multiphase ac ots" begin
     @testset "3-bus 3-phase case" begin
         mp_data = PMs.parse_file("../../PowerModels/test/data/matpower/case3.m")
-        PMs.make_multiphase(mp_data, 3)
+        PMs.make_multiconductor(mp_data, 3)
         result = run_tp_ots(mp_data, PMs.ACPPowerModel, juniper_solver)
 
         @test result["status"] == :LocalOptimal
@@ -42,7 +42,7 @@ end
 
         @testset "3-bus 3-phase case" begin
             mp_data = PMs.parse_file("../../PowerModels/test/data/matpower/case3.m")
-            PMs.make_multiphase(mp_data, 3)
+            PMs.make_multiconductor(mp_data, 3)
             result = run_tp_ots(mp_data, PMs.DCPPowerModel, pajarito_solver)
 
             @test result["status"] == :Optimal
@@ -53,7 +53,7 @@ end
 
         @testset "5-bus 3-phase case" begin
             mp_data = PMs.parse_file("../test/data/matlab/case5.m")
-            PMs.make_multiphase(mp_data, 3)
+            PMs.make_multiconductor(mp_data, 3)
             result = run_tp_ots(mp_data, PMs.DCPPowerModel, pajarito_solver)
 
             @test result["status"] == :Optimal

--- a/test/tp_pf.jl
+++ b/test/tp_pf.jl
@@ -27,7 +27,7 @@
         @test sol["status"] == :LocalOptimal
 
         @test all(isapprox.(sol["solution"]["bus"]["2"]["vm"].values, 0.984377; atol=1e-4))
-        @test all(isapprox.(sol["solution"]["bus"]["2"]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) - deg2rad(0.79) for ph in 1:tppm["phases"]]; atol=deg2rad(0.2)))
+        @test all(isapprox.(sol["solution"]["bus"]["2"]["va"].values, [2 * pi / tppm["conductors"] * (c - 1) - deg2rad(0.79) for c in 1:tppm["conductors"]]; atol=deg2rad(0.2)))
 
         @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.018209; atol=1e-5)
         @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.000208979; atol=1e-5)
@@ -40,7 +40,7 @@
         @test sol["status"] == :LocalOptimal
 
         for (bus, va, vm) in zip(["1", "2", "3"], [0.0, deg2rad(-0.08), deg2rad(-0.17)], [0.9959, 0.986559, 0.97572])
-            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) + va for ph in 1:tppm["phases"]]; atol=deg2rad(0.2)))
+            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["conductors"] * (c - 1) + va for c in 1:tppm["conductors"]]; atol=deg2rad(0.2)))
             @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=1e-3))
         end
 
@@ -57,7 +57,7 @@
         for (bus, va, vm) in zip(["1", "2", "3"],
                                 [0.0, deg2rad.([-0.30, 0.09, -0.17]), deg2rad.([-0.65, 0.20, -0.36])],
                                 [0.9959, [0.980269, 0.986645, 0.989161], [0.962159, 0.975897, 0.981341]])
-            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["phases"] * (ph - 1) for ph in 1:tppm["phases"]] + va; atol=deg2rad(0.2)))
+            @test all(isapprox.(sol["solution"]["bus"][bus]["va"].values, [2 * pi / tppm["conductors"] * (c - 1) for c in 1:tppm["conductors"]] + va; atol=deg2rad(0.2)))
             @test all(isapprox.(sol["solution"]["bus"][bus]["vm"].values, vm; atol=2e-3))
         end
 


### PR DESCRIPTION
An update that works with https://github.com/lanl-ansi/PowerModels.jl/pull/324

@pseudocubic, please review.  Especially if I did the OpenDSS part correctly.

In terms of temp variables I changed `h` to `c` and `g` to `d`.

Once you are happy with this, squash merge the PowerModels PR and this one.