### PR TITLE
Fix/opendss validation

### DIFF
--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -324,14 +324,10 @@ function parse_matrix(data::Array{T}, nodes::Array{Bool}, nph::Int=3, fill_val=0
     mat = fill(fill_val, (nph, nph))
     idxs = find(nodes[1:nph])
 
-    if size(data) == size(mat)
-        return data
-    else
-        for i in 1:size(data)[1]
-            mat[idxs[i], idxs[i]] = data[i, i]
-            for j in 1:i-1
-                mat[idxs[i],idxs[j]] = mat[idxs[j],idxs[i]] = data[i, j]
-            end
+    for i in 1:size(idxs)[1]
+        mat[idxs[i], idxs[i]] = data[i, i]
+        for j in 1:i-1
+            mat[idxs[i],idxs[j]] = mat[idxs[j],idxs[i]] = data[i, j]
         end
     end
 
@@ -404,14 +400,12 @@ function parse_array(data, nodes::Array{Bool}, nph::Int=3, fill_val=0.0)::Array
     mat = fill(fill_val, nph)
     idxs = find(nodes[1:nph])
 
-    if size(data) == size(mat)
-        return data
-    elseif length(data) == 1 && nph > 1
+    if length(data) == 1 && nph > 1
         for i in idxs
             mat[i] = data[1]
         end
     else
-        for i in 1:length(data)
+        for i in 1:length(idxs)
             mat[idxs[i]] = data[i]
         end
     end

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -289,7 +289,14 @@ function parse_matrix(dtype::Type, data::AbstractString)::Array
 
     nphases = maximum([length(row) for row in rows])
 
-    matrix = zeros(dtype, nphases, nphases)
+    if dtype == AbstractString || dtype == String
+        matrix = fill("", nphases, nphases)
+    elseif dtype == Char
+        matrix = fill(' ', nphases, nphases)
+    else
+        matrix = zeros(dtype, nphases, nphases)
+    end
+
     if length(rows) == 1
         for i in 1:nphases
             matrix[i, i] = rows[1][1]
@@ -372,7 +379,7 @@ function parse_array(dtype::Type, data::AbstractString)
         elements = [strip(el) for el in elements if strip(el) != ""]
     end
 
-    if dtype == String
+    if dtype == String || dtype == AbstractString || dtype == Char
         array = []
         for el in elements
             push!(array, el)
@@ -618,7 +625,10 @@ function parse_component(component::AbstractString, properties::AbstractString, 
             end
 
             try
-                propIdx = find(e->e==split(property,'=')[1], propNames)[1] + 1
+                propIdxs = find(e->e==split(property,'=')[1], propNames)
+                if length(propIdxs) > 0
+                    propIdx = find(e->e==split(property,'=')[1], propNames)[1] + 1
+                end
             catch e
                 if split(component,'.')[1] == "transformer"
                     if split(property,'=')[1] == "ppm"

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -25,8 +25,8 @@ function create_starbus(tppm_data::Dict, transformer::Dict)::Dict
 
     starbus["bus_i"] = starbus_id
     starbus["base_kv"] = 1.0
-    starbus["vmin"] = PMs.MultiConductorVector(parse_array(0.9, nodes, nconductors))
-    starbus["vmax"] = PMs.MultiConductorVector(parse_array(1.1, nodes, nconductors))
+    starbus["vmin"] = PMs.MultiConductorVector(parse_array(0.9, nodes, nconductors, 0.9))
+    starbus["vmax"] = PMs.MultiConductorVector(parse_array(1.1, nodes, nconductors, 1.1))
     starbus["name"] = "$(transformer["name"]) starbus"
     starbus["vm"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors))
     starbus["va"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
@@ -109,8 +109,8 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
         busDict["vm"] = PMs.MultiConductorVector(parse_array(vm, nodes, nconductors))
         busDict["va"] = PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nconductors*(i-1))+ph1_ang for i in 1:nconductors], nodes, nconductors))
 
-        busDict["vmin"] = PMs.MultiConductorVector(parse_array(vmi, nodes, nconductors))
-        busDict["vmax"] = PMs.MultiConductorVector(parse_array(vma, nodes, nconductors))
+        busDict["vmin"] = PMs.MultiConductorVector(parse_array(vmi, nodes, nconductors, vmi))
+        busDict["vmax"] = PMs.MultiConductorVector(parse_array(vma, nodes, nconductors, vma))
 
         busDict["base_kv"] = tppm_data["basekv"]
 

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -174,6 +174,12 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             nconductors = tppm_data["conductors"]
             name, nodes = parse_busname(defaults["bus1"])
 
+            kv = defaults["kv"]
+            expected_kv = tppm_data["basekv"] / sqrt(tppm_data["conductors"])
+            if !isapprox(kv, expected_kv; atol=expected_kv * 0.01)
+                warn(LOGGER, "Load has kv=$kv, not the expected kv=$(@sprintf("%.3f", expected_kv)). Results may not match OpenDSS")
+            end
+
             loadDict["name"] = defaults["name"]
             loadDict["load_bus"] = find_bus(name, tppm_data)
             loadDict["pd"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nconductors))

--- a/test/data/opendss/case2_1phase.dss
+++ b/test/data/opendss/case2_1phase.dss
@@ -1,0 +1,17 @@
+clear
+
+new circuit.c2
+~ basekv=0.4 pu=1 MVAsc1=1e6 MVAsc3=1e6
+
+new line.OHLine phases=1 bus1=sourcebus.1 bus2=loadbus.1
+~ rmatrix = ( 0.1 )
+~ xmatrix = ( 0.01 )
+~ cmatrix = ( 50 )
+
+new load.L1 phases=1 loadbus.1 kw=6 kvar=3 kv=( 0.4 3 sqrt / )
+
+set voltagebases=[0.4]
+set tolerance=0.000001
+Calcvoltagebases
+
+solve

--- a/test/data/opendss/case5_doppedphases.dss
+++ b/test/data/opendss/case5_doppedphases.dss
@@ -1,0 +1,25 @@
+clear
+
+new circuit.c3
+~ basekv=0.4 pu=1 MVAsc1=1e6 MVAsc3=1e6
+
+new linecode.lc1
+~ rmatrix = [ 0.1 | 0.0 0.1 | 0.0 0.0 0.1 ]
+~ xmatrix = [ 0.01 | 0.0 0.01 | 0.0 0.0 0.01 ]
+~ cmatrix = [ 50 | 0 50 | 0 0 50 ]
+
+new line.line1 bus1=sourcebus.1.2.3.0 bus2=midbus.1.2.3.0 linecode=lc1
+new line.line2 bus1=midbus.1 bus2=l1.1 linecode=lc1
+new line.line3 bus1=midbus.2.3 bus2=l2.2.3 linecode=lc1
+new line.line4 bus1=midbus.3 bus2=cap1.3 linecode=lc1
+
+new load.load1 phases=1 bus1=l1.1 kv=( 0.4 3 sqrt / ) kw=6 kvar=3
+new load.load2 phases=1 bus1=l2.2 kv=( 0.4 3 sqrt / ) kw=6 kvar=3
+new load.load3 phases=1 bus1=l2.3 kv=( 0.4 3 sqrt / ) kw=6 kvar=3
+
+new capacitor.capac1 phases=1 bus1=cap1.3 kvar=4.5 kv=( 0.4 3 sqrt / )
+
+set voltagebases=[0.4]
+calcvoltagebases
+
+solve


### PR DESCRIPTION
Fixes for various issues related to OpenDSS validation, including:

Adds support for undocumented properties, and fixes issue with parsing string/char matrices and arrays related to this.

Fixes issue where matrices where not getting zeroed out where conductors were inactive.

Adds warning for inconsistent `kv` values in loads.

Adds warning for missing `defaultbasefreq` and inconsistent usage of `basefreq` on lines.

Adds better bounds for `pmin, pmax, qmin, qmax` by checking `emergamps` of all connected lines and summing them.

Adds two OpenDSS test cases related to dropping of phases in Issue #22 

Closes #65 
Closes #64  
Closes #63  
Closes #62 
Closes #59 