### PR TITLE
typo fix in dss_structs.jl

### DIFF
--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -623,14 +623,14 @@ function createVSource(bus1, name::AbstractString, bus2=0; kwargs...)
 
     Zbase = basekv^2 / basemva
 
-    if (haskey(kwargs, :mvasc3) && haskey(kwargs, :mvasc1)) || (haskey(kwargs, :isc3) && haskey(isc1, :isc1))
+    if (haskey(kwargs, :mvasc3) && haskey(kwargs, :mvasc1)) || (haskey(kwargs, :isc3) && haskey(kwargs, :isc1))
         if haskey(kwargs, :mvasc3) && haskey(kwargs, :mvasc1)
             mvasc3 = kwargs[:mvasc3]
             mvasc1 = kwargs[:mvasc1]
 
             isc3 = mvasc3 * 1e3 / (basekv * sqrt(3.0))
             isc1 = mvasc1 * 1e3 / (basekv * factor)
-        elseif haskey(kwargs, :isc3) && haskey(isc1, :isc1)
+        elseif haskey(kwargs, :isc3) && haskey(kwargs, :isc1)
             isc3 = kwargs[:isc3]
             isc1 = kwargs[:isc1]
 

--- a/test/data/opendss/case3_balanced_isc.dss
+++ b/test/data/opendss/case3_balanced_isc.dss
@@ -1,0 +1,37 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  ISC1=1e9  ISC3=1e9
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve


### PR DESCRIPTION
solving issue #86 

corrected two typos (isc1=>kwargs) and added a version of case3_balanced.dss that specifies ISC1 and ISC3 instead of MVAsc1 and MVAsc3, which revealed this bug in the first place