### PR TITLE
FIX: bug in parsing ~ lines with preceeding whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ ThreePhasePowerModels.jl Change Log
 
 ### Staged
 - Minor fix to branch parsing in matlab format
+- Minor fix to OpenDSS parser (parsing ~ lines with preceeding whitespace)
 
 ### v0.1.2
-- Add support for network flow approximation formulation, NFAPowerModel 
+- Add support for network flow approximation formulation, NFAPowerModel
 - Updates to problem specifications
 - Update tests for SCS v0.4
 - Minor improvements to OpenDSS parser

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -758,7 +758,7 @@ function parse_dss(io::IOStream)::Dict
         line = lowercase(strip_comments(line))
 
         if startswith(strip(line), '~')
-            curCompDict = parse_component(curCtypeName, strip(strip(line, '~')), curCompDict)
+            curCompDict = parse_component(curCtypeName, strip(strip(line),  '~'), curCompDict)
 
             if n < nlines && startswith(strip(stripped_lines[n + 1]), '~')
                 continue

--- a/test/data/opendss/test_transformer_formatting.dss
+++ b/test/data/opendss/test_transformer_formatting.dss
@@ -1,0 +1,8 @@
+new circuit.c1
+
+new transformer.transformer_test kva=20000.0
+	~ phases=3 windings=2
+	~ %loadloss=0.01 xhl=0.02
+	~ wdg=1 bus=from_bus.1.2.3 conn=delta kv=67.0
+	~ wdg=2 bus=to_bus.1.2.3 conn=wye kv=12.47
+	~ tap=1.0 maxtap=0.0 mintap=-0.0

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -164,6 +164,11 @@ TESTLOG = getlogger(PowerModels)
             @test tppm["branch"]["8"]["switch"]
             @test all([tppm["branch"]["$i"]["switch"] == false for i in 1:6])
         end
+
+        @testset "whitespace before ~" begin
+            dss_data = TPPMs.parse_dss("../test/data/opendss/test_transformer_formatting.dss")
+            @test dss_data["transformer"][1]["phases"] == "3"
+        end
     end
 
     @testset "2-bus diagonal" begin


### PR DESCRIPTION
In opendss `~` indicates continuation of previous line, but in cases
where whitespace preceeded the `~` character, that character was
inserted into the parsed data (in the specific case where this was
discovered, into the `phases` data field of a transformer. The order
of the `strip` commands was changed to `strip(strip(line), "~")` to
solve this problem. Unit test is included.