### PR TITLE
ADD OpenDSS storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ ThreePhasePowerModels.jl Change Log
 ===================================
 
 ### Staged
+- Add support for parsing OpenDSS Storage objects
 - Minor fix to branch parsing in matlab format
 - Minor fix to OpenDSS parser (parsing ~ lines with preceeding whitespace)
 

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -196,12 +196,12 @@ function get_prop_name(ctype::AbstractString)::Array
                   "d", "purs", "puxs", "purr", "puxr", "puxm", "slip",
                   "maxslip", "slipoption", "spectrum", "enabled"]
 
-    storage = ["%charge", "%discharge", "%effcharge", "%idlingkvar", "idlingkw",
-               "%r", "%reserve", "%stored", "%x", "basefreq", "bus1", "chargetrigger",
-               "class", "conn", "daily", "yearly", "debugtrace", "dischargetrigger",
-               "dispmode", "duty", "dynadata", "dynadll", "enabled", "kv", "kva",
-               "kvar", "kw", "kwhrated", "kwhstored", "kwrated", "like", "model",
-               "pf", "phases", "spectrum", "state", "timechargetrig", "userdata",
+    storage = ["phases", "bus1", "%charge", "%discharge", "%effcharge", "%idlingkvar",
+               "idlingkw", "%r", "%reserve", "%stored", "%x", "basefreq",
+               "chargetrigger", "class", "conn", "daily", "yearly", "debugtrace",
+               "dischargetrigger", "dispmode", "duty", "dynadata", "dynadll", "enabled",
+               "kv", "kva", "kvar", "kw", "kwhrated", "kwhstored", "kwrated", "like",
+               "model", "pf", "spectrum", "state", "timechargetrig", "userdata",
                "usermodel", "vmaxpu", "vminpu", "yearly"]
 
     capcontrol = ["element", "capacitor", "type", "ctphase", "ctratio", "deadtime",

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -992,6 +992,8 @@ element. See OpenDSS documentation for valid fields and ways to specify the
 different properties.
 """
 function createStorage(bus1, name::AbstractString; kwargs...)
+    kwargs = Dict{Symbol,Any}(kwargs)
+
     storage = Dict{String,Any}("name" => name,
                                "%charge" => get(kwargs, :charge, 100.0),
                                "%discharge" => get(kwargs, :discharge, 100.0),

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -983,6 +983,62 @@ function createPVSystem(bus1, name::AbstractString; kwargs...)
     return pvsystem
 end
 
+
+"""
+    createStorage(bus1, name; kwargs...)
+
+Creates a Dict{String,Any} containing all expected properties for a storage
+element. See OpenDSS documentation for valid fields and ways to specify the
+different properties.
+"""
+function createStorage(bus1, name::AbstractString; kwargs...)
+    storage = Dict{String,Any}("name" => name,
+                               "%charge" => get(kwargs, :charge, 100.0),
+                               "%discharge" => get(kwargs, :discharge, 100.0),
+                               "%effcharge" => get(kwargs, :effcharge, 90.0),
+                               "%effdischarge" => get(kwargs, :effdischarge, 90.0),
+                               "%idlingkvar" => get(kwargs, :idlingkvar, 0.0),
+                               "%idlingkw" => get(kwargs, :idlingkw, 1.0),
+                               "%r" => get(kwargs, :r, 0.0),
+                               "%reserve" => get(kwargs, :reserve, 20.0),
+                               "%stored" => get(kwargs, :stored, 100.0),
+                               "%x" => get(kwargs, :x, 50.0),
+                               "basefreq" => get(kwargs, :basefreq, 60.0),
+                               "bus1" => bus1,
+                               "chargetrigger" => get(kwargs, :chargetrigger, 0.0),
+                               "class" => get(kwargs, :class, 0),
+                               "conn" => get(kwargs, :conn, "wye"),
+                               "daily" => get(kwargs, :daily, [1.0, 1.0]),
+                               "debugtrace" => get(kwargs, :debugtrace, false),
+                               "dischargetrigger" => get(kwargs, :dischargetrigger, 0.0),
+                               "dispmode" => get(kwargs, :dispmode, "default"),
+                               "duty" => get(kwargs, :duty, ""),
+                               "dynadata" => get(kwargs, :dynadata, ""),
+                               "dynadll" => get(kwargs, :dynadll, "none"),
+                               "enabled" => get(kwargs, :enabled, true),
+                               "kv" => get(kwargs, :kv, 12.47),
+                               "kw" => get(kwargs, :kw, 0.0),
+                               "kva" => get(kwargs, :kva, 25.0),
+                               "kvar" => get(kwargs, :kvar, 0.0),
+                               "kwhrated" => get(kwargs, :kwhrated, 50.0),
+                               "kwhstored" => get(kwargs, :kwhstored, 50.0),
+                               "kwrated" => get(kwargs, :kwrated, 50.0),
+                               "model" => get(kwargs, :model, 1),
+                               "pf" => get(kwargs, :pf, 1.0),
+                               "phases" => get(kwargs, :phases, 3),
+                               "spectrum" => get(kwargs, :spectrum, "default"),
+                               "state" => get(kwargs, :state, "idling"),
+                               "timechargetrig" => get(kwargs, :timechargetrig, 2.0),
+                               "userdata" => get(kwargs, :userdata, ""),
+                               "usermodel" => get(kwargs, :usermodel, "none"),
+                               "vmaxpu" => get(kwargs, :vmaxpu, 1.1),
+                               "vminpu" => get(kwargs, :vimpu, 0.9),
+                               "yearly" => get(kwargs, :yearly, [1.0, 1.0]),
+                              )
+    return storage
+end
+
+
 "Returns a Dict{String,Type} for the desired component `comp`, giving all of the expected data types"
 function get_dtypes(comp::AbstractString)::Dict
     default_dicts = Dict{String,Any}("line" => createLine("", "", ""),
@@ -994,7 +1050,8 @@ function get_dtypes(comp::AbstractString)::Dict
                                      "linecode" => createLinecode(""),
                                      "circuit" => createVSource("", ""),
                                      "pvsystem" => createPVSystem("", ""),
-                                     "vsource" => createVSource("", "", "")
+                                     "vsource" => createVSource("", "", ""),
+                                     "storage" => createStorage("", "")
                                     )
 
     return Dict{String,Type}((k, typeof(v)) for (k, v) in default_dicts[comp])

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -779,10 +779,9 @@ function parse_opendss(dss_data::Dict; import_all::Bool=false, vmin::Float64=0.9
 
     check_duplicate_components!(dss_data)
 
-    # parse_dss_with_dtypes!(dss_data, ["line", "linecode", "load", "generator", "capacitor",
-    #                                   "reactor", "circuit", "transformer"])
     parse_dss_with_dtypes!(dss_data, ["line", "linecode", "load", "generator", "capacitor",
-                                      "reactor", "circuit", "transformer", "pvsystem"])
+                                      "reactor", "circuit", "transformer", "pvsystem",
+                                      "storage"])
 
     if haskey(dss_data, "options")
         condensed_opts = [Dict{String,Any}()]

--- a/test/data/opendss/case3_balanced_battery.dss
+++ b/test/data/opendss/case3_balanced_battery.dss
@@ -1,0 +1,39 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+New Storage.S1 phases=3 bus1=primary.1.2.3 kv=( 0.4 3 sqrt / ) kwhstored=50 kwhrated=50 kva=100 kvar=100
+~ %charge=100 %discharge=100 %effcharge=100 %effdischarge=100 %idlingkw=1 %r=0 %x=50
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -96,7 +96,7 @@ TESTLOG = getlogger(PowerModels)
         tppm = TPPMs.parse_file("../test/data/opendss/test2_master.dss")
 
         @test tppm["name"] == "test2"
-        @test length(tppm) == 18
+        @test length(tppm) == 19
         @test length(dss) == 12
 
         for (key, len) in zip(["bus", "load", "shunt", "branch", "gen", "dcline"], [11, 4, 5, 15, 4, 0])
@@ -168,6 +168,20 @@ TESTLOG = getlogger(PowerModels)
         @testset "whitespace before ~" begin
             dss_data = TPPMs.parse_dss("../test/data/opendss/test_transformer_formatting.dss")
             @test dss_data["transformer"][1]["phases"] == "3"
+        end
+
+        @testset "storage parse" begin
+            tppm_storage = TPPMs.parse_file("../test/data/opendss/case3_balanced_battery.dss")
+            for bat in values(tppm_storage["storage"])
+                for key in ["energy", "storage_bus", "energy_rating", "charge_rating", "discharge_rating",
+                            "charge_efficiency", "discharge_efficiency", "thermal_rating", "qmin", "qmax",
+                            "r", "x", "standby_loss", "status"]
+                    @test haskey(bat, key)
+                    if key in ["x", "r", "qmin", "qmax", "thermal_rating"]
+                        @test isa(bat[key], PowerModels.MultiConductorVector)
+                    end
+                end
+            end
         end
     end
 


### PR DESCRIPTION
Adds support for basic parsing of OpenDSS Storage objects (see OpenDSS manual) into the PowerModels storage data model (see https://lanl-ansi.github.io/PowerModels.jl/latest/storage/).