### PR TITLE
ADD: 'source_id' to identify source of PM components from OpenDSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ThreePhasePowerModels.jl Change Log
 - Minor fix to branch parsing in matlab format
 - Minor fix to OpenDSS parser (parsing ~ lines with preceeding whitespace)
 - Fixed parsing OpenDSS files containing redirect/compile/buscoords on case-sensitive filesystems
+- Add 'source_id' field to components parsed from OpenDSS, to help determine origin and active phases
 
 ### v0.1.2
 - Add support for network flow approximation formulation, NFAPowerModel

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -183,24 +183,24 @@ TESTLOG = getlogger(PowerModels)
                 end
             end
 
-            @test tppm_storage["storage"]["1"]["source_id"] == "storage.s1" && sum(tppm_storage["storage"]["1"]["active_phases"]) == 3
+            @test tppm_storage["storage"]["1"]["source_id"] == "storage.s1" && length(tppm_storage["storage"]["1"]["active_phases"]) == 3
         end
 
         @testset "source_id check" begin
-            @test tppm["shunt"]["1"]["source_id"] == "capacitor.c1" && sum(tppm["shunt"]["1"]["active_phases"]) == 3
-            @test tppm["shunt"]["4"]["source_id"] == "reactor.reactor3" && sum(tppm["shunt"]["4"]["active_phases"]) == 3
+            @test tppm["shunt"]["1"]["source_id"] == "capacitor.c1" && length(tppm["shunt"]["1"]["active_phases"]) == 3
+            @test tppm["shunt"]["4"]["source_id"] == "reactor.reactor3" && length(tppm["shunt"]["4"]["active_phases"]) == 3
 
-            @test tppm["branch"]["1"]["source_id"] == "line.l1" && sum(tppm["branch"]["1"]["active_phases"]) == 3
-            @test tppm["branch"]["13"]["source_id"] == "transformer.t5" && sum(tppm["branch"]["13"]["active_phases"]) == 3
-            @test tppm["branch"]["14"]["source_id"] == "reactor.reactor1" && sum(tppm["branch"]["14"]["active_phases"]) == 3
+            @test tppm["branch"]["1"]["source_id"] == "line.l1" && length(tppm["branch"]["1"]["active_phases"]) == 3
+            @test tppm["branch"]["13"]["source_id"] == "transformer.t5" && length(tppm["branch"]["13"]["active_phases"]) == 3
+            @test tppm["branch"]["14"]["source_id"] == "reactor.reactor1" && length(tppm["branch"]["14"]["active_phases"]) == 3
 
-            @test tppm["gen"]["1"]["source_id"] == "vsource.sourcebus" && sum(tppm["gen"]["1"]["active_phases"]) == 3
-            @test tppm["gen"]["2"]["source_id"] == "generator.g1" && sum(tppm["gen"]["2"]["active_phases"]) == 3
+            @test tppm["gen"]["1"]["source_id"] == "vsource.sourcebus" && length(tppm["gen"]["1"]["active_phases"]) == 3
+            @test tppm["gen"]["2"]["source_id"] == "generator.g1" && length(tppm["gen"]["2"]["active_phases"]) == 3
 
             source_id = TPPMs.parse_dss_source_id(tppm["load"]["1"])
             @test source_id.dss_type == "load"
             @test source_id.dss_name == "ld1"
-            @test all(source_id.active_phases .== [1, 1, 0])
+            @test all([n in source_id.active_phases for n in 1:2])
 
             for component_type in ["load", "branch", "shunt", "gen", "storage", "pvsystem"]
                 for component in values(get(tppm, component_type, Dict()))

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -134,7 +134,7 @@ TESTLOG = getlogger(PowerModels)
         end
 
         for k in keys(tppm["gen"]["3"])
-            if !(k in ["gen_bus", "index", "name", "source_type", "source_name", "active_phases"])
+            if !(k in ["gen_bus", "index", "name", "source_id", "active_phases"])
                 if isa(tppm["gen"]["3"][k], PMs.MultiConductorValue)
                     @test all(isapprox.(tppm["gen"]["4"][k].values, tppm["gen"]["3"][k].values; atol=1e-12))
                 else
@@ -144,7 +144,7 @@ TESTLOG = getlogger(PowerModels)
         end
 
         for k in keys(tppm["branch"]["15"])
-            if !(k in ["f_bus", "t_bus", "index", "name", "linecode", "source_type", "source_name", "active_phases"])
+            if !(k in ["f_bus", "t_bus", "index", "name", "linecode", "source_id", "active_phases"])
                 if isa(tppm["branch"]["15"][k], PMs.MultiConductorValue)
                     @test all(isapprox.(tppm["branch"]["14"][k].values, tppm["branch"]["15"][k].values; atol=1e-12))
                     @test all(isapprox.(tppm["branch"]["12"][k].values, tppm["branch"]["13"][k].values; atol=1e-12))
@@ -175,7 +175,7 @@ TESTLOG = getlogger(PowerModels)
             for bat in values(tppm_storage["storage"])
                 for key in ["energy", "storage_bus", "energy_rating", "charge_rating", "discharge_rating",
                             "charge_efficiency", "discharge_efficiency", "thermal_rating", "qmin", "qmax",
-                            "r", "x", "standby_loss", "status", "source_type", "source_name", "active_phases"]
+                            "r", "x", "standby_loss", "status", "source_id", "active_phases"]
                     @test haskey(bat, key)
                     if key in ["x", "r", "qmin", "qmax", "thermal_rating"]
                         @test isa(bat[key], PowerModels.MultiConductorVector)
@@ -183,19 +183,19 @@ TESTLOG = getlogger(PowerModels)
                 end
             end
 
-            @test tppm_storage["storage"]["1"]["source_type"] == "storage" && tppm_storage["storage"]["1"]["source_name"] == "s1" && sum(tppm_storage["storage"]["1"]["active_phases"]) == 3
+            @test tppm_storage["storage"]["1"]["source_id"] == "storage.s1" && sum(tppm_storage["storage"]["1"]["active_phases"]) == 3
         end
 
         @testset "source_id check" begin
-            @test tppm["shunt"]["1"]["source_type"] == "capacitor" && tppm["shunt"]["1"]["source_name"] == "c1" && sum(tppm["shunt"]["1"]["active_phases"]) == 3
-            @test tppm["shunt"]["4"]["source_type"] == "reactor" && tppm["shunt"]["4"]["source_name"] == "reactor3" && sum(tppm["shunt"]["4"]["active_phases"]) == 3
+            @test tppm["shunt"]["1"]["source_id"] == "capacitor.c1" && sum(tppm["shunt"]["1"]["active_phases"]) == 3
+            @test tppm["shunt"]["4"]["source_id"] == "reactor.reactor3" && sum(tppm["shunt"]["4"]["active_phases"]) == 3
 
-            @test tppm["branch"]["1"]["source_type"] == "line" && tppm["branch"]["1"]["source_name"] == "l1" && sum(tppm["branch"]["1"]["active_phases"]) == 3
-            @test tppm["branch"]["13"]["source_type"] == "transformer" && tppm["branch"]["13"]["source_name"] == "t5" && sum(tppm["branch"]["13"]["active_phases"]) == 3
-            @test tppm["branch"]["14"]["source_type"] == "reactor" && tppm["branch"]["14"]["source_name"] == "reactor1" && sum(tppm["branch"]["14"]["active_phases"]) == 3
+            @test tppm["branch"]["1"]["source_id"] == "line.l1" && sum(tppm["branch"]["1"]["active_phases"]) == 3
+            @test tppm["branch"]["13"]["source_id"] == "transformer.t5" && sum(tppm["branch"]["13"]["active_phases"]) == 3
+            @test tppm["branch"]["14"]["source_id"] == "reactor.reactor1" && sum(tppm["branch"]["14"]["active_phases"]) == 3
 
-            @test tppm["gen"]["1"]["source_type"] == "vsource" && tppm["gen"]["1"]["source_name"] == "sourcebus" && sum(tppm["gen"]["1"]["active_phases"]) == 3
-            @test tppm["gen"]["2"]["source_type"] == "generator" &&tppm["gen"]["2"]["source_name"] == "g1" && sum(tppm["gen"]["2"]["active_phases"]) == 3
+            @test tppm["gen"]["1"]["source_id"] == "vsource.sourcebus" && sum(tppm["gen"]["1"]["active_phases"]) == 3
+            @test tppm["gen"]["2"]["source_id"] == "generator.g1" && sum(tppm["gen"]["2"]["active_phases"]) == 3
 
             source_id = TPPMs.parse_dss_source_id(tppm["load"]["1"])
             @test source_id.dss_type == "load"
@@ -204,8 +204,7 @@ TESTLOG = getlogger(PowerModels)
 
             for component_type in ["load", "branch", "shunt", "gen", "storage", "pvsystem"]
                 for component in values(get(tppm, component_type, Dict()))
-                    @test haskey(component, "source_type")
-                    @test haskey(component, "source_name")
+                    @test haskey(component, "source_id")
                     @test haskey(component, "active_phases")
                 end
             end

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -134,7 +134,7 @@ TESTLOG = getlogger(PowerModels)
         end
 
         for k in keys(tppm["gen"]["3"])
-            if !(k in ["gen_bus", "index", "name", "source_id"])
+            if !(k in ["gen_bus", "index", "name", "source_type", "source_name", "active_phases"])
                 if isa(tppm["gen"]["3"][k], PMs.MultiConductorValue)
                     @test all(isapprox.(tppm["gen"]["4"][k].values, tppm["gen"]["3"][k].values; atol=1e-12))
                 else
@@ -144,7 +144,7 @@ TESTLOG = getlogger(PowerModels)
         end
 
         for k in keys(tppm["branch"]["15"])
-            if !(k in ["f_bus", "t_bus", "index", "name", "linecode", "source_id"])
+            if !(k in ["f_bus", "t_bus", "index", "name", "linecode", "source_type", "source_name", "active_phases"])
                 if isa(tppm["branch"]["15"][k], PMs.MultiConductorValue)
                     @test all(isapprox.(tppm["branch"]["14"][k].values, tppm["branch"]["15"][k].values; atol=1e-12))
                     @test all(isapprox.(tppm["branch"]["12"][k].values, tppm["branch"]["13"][k].values; atol=1e-12))
@@ -175,7 +175,7 @@ TESTLOG = getlogger(PowerModels)
             for bat in values(tppm_storage["storage"])
                 for key in ["energy", "storage_bus", "energy_rating", "charge_rating", "discharge_rating",
                             "charge_efficiency", "discharge_efficiency", "thermal_rating", "qmin", "qmax",
-                            "r", "x", "standby_loss", "status", "source_id"]
+                            "r", "x", "standby_loss", "status", "source_type", "source_name", "active_phases"]
                     @test haskey(bat, key)
                     if key in ["x", "r", "qmin", "qmax", "thermal_rating"]
                         @test isa(bat[key], PowerModels.MultiConductorVector)
@@ -183,30 +183,30 @@ TESTLOG = getlogger(PowerModels)
                 end
             end
 
-            @test tppm_storage["storage"]["1"]["source_id"] == "storage.s1.1.2.3"
+            @test tppm_storage["storage"]["1"]["source_type"] == "storage" && tppm_storage["storage"]["1"]["source_name"] == "s1" && sum(tppm_storage["storage"]["1"]["active_phases"]) == 3
         end
 
         @testset "source_id check" begin
-            @test tppm["load"]["1"]["source_id"] == "load.ld1.1.2"
+            @test tppm["shunt"]["1"]["source_type"] == "capacitor" && tppm["shunt"]["1"]["source_name"] == "c1" && sum(tppm["shunt"]["1"]["active_phases"]) == 3
+            @test tppm["shunt"]["4"]["source_type"] == "reactor" && tppm["shunt"]["4"]["source_name"] == "reactor3" && sum(tppm["shunt"]["4"]["active_phases"]) == 3
 
-            @test tppm["shunt"]["1"]["source_id"] == "capacitor.c1.1.2.3"
-            @test tppm["shunt"]["4"]["source_id"] == "reactor.reactor3.1.2.3"
+            @test tppm["branch"]["1"]["source_type"] == "line" && tppm["branch"]["1"]["source_name"] == "l1" && sum(tppm["branch"]["1"]["active_phases"]) == 3
+            @test tppm["branch"]["13"]["source_type"] == "transformer" && tppm["branch"]["13"]["source_name"] == "t5" && sum(tppm["branch"]["13"]["active_phases"]) == 3
+            @test tppm["branch"]["14"]["source_type"] == "reactor" && tppm["branch"]["14"]["source_name"] == "reactor1" && sum(tppm["branch"]["14"]["active_phases"]) == 3
 
-            @test tppm["branch"]["1"]["source_id"] == "line.l1.1.2.3"
-            @test tppm["branch"]["13"]["source_id"] == "transformer.t5.1.2.3"
-            @test tppm["branch"]["14"]["source_id"] == "reactor.reactor1.1.2.3"
+            @test tppm["gen"]["1"]["source_type"] == "vsource" && tppm["gen"]["1"]["source_name"] == "sourcebus" && sum(tppm["gen"]["1"]["active_phases"]) == 3
+            @test tppm["gen"]["2"]["source_type"] == "generator" &&tppm["gen"]["2"]["source_name"] == "g1" && sum(tppm["gen"]["2"]["active_phases"]) == 3
 
-            @test tppm["gen"]["1"]["source_id"] == "vsource.sourcebus.1.2.3"
-            @test tppm["gen"]["2"]["source_id"] == "generator.g1.1.2.3"
-
-            source_id = TPPMs.parse_source_id(tppm["load"]["1"]["source_id"])
-            @test source_id["type"] == "load"
-            @test source_id["name"] == "ld1"
-            @test all(source_id["phases"] .== [true, true, false])
+            source_id = TPPMs.parse_dss_source_id(tppm["load"]["1"])
+            @test source_id.dss_type == "load"
+            @test source_id.dss_name == "ld1"
+            @test all(source_id.active_phases .== [1, 1, 0])
 
             for component_type in ["load", "branch", "shunt", "gen", "storage", "pvsystem"]
                 for component in values(get(tppm, component_type, Dict()))
-                    @test haskey(component, "source_id")
+                    @test haskey(component, "source_type")
+                    @test haskey(component, "source_name")
+                    @test haskey(component, "active_phases")
                 end
             end
         end


### PR DESCRIPTION
Adds three source id related fields to supported PowerModels components,
including "load", "shunt", "branch" (incl. transformers and starbuses), "gen",
"storage", and "pysystem". Buses do not have such fields because of
their implicit declarations in OpenDSS, with the exception of starbuses,
who originate from 3-winding transformers. 

Each supported component will contain three new source-related fields:
"source_id" and "active_phases". "source_id" has the format
"source_type.source_name". "active_phases" is represented as a sparse
array, where each active phase number is included, e.g. `[2, 3]` if phases
2 and 3 are active.

The function `parse_dss_source_id(component)` will return a custom struct
with members `dss_type`, `dss_name` and `active_phases` for easy
aggregation of this information.

Unit tests added for existing models.

Closes #100 