### PR TITLE
ADD: OpenDSS PVSystem to PM Generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ThreePhasePowerModels.jl Change Log
 - Minor fix to OpenDSS parser (parsing ~ lines with preceeding whitespace)
 - Fixed parsing OpenDSS files containing redirect/compile/buscoords on case-sensitive filesystems
 - Add 'source_id' field to components parsed from OpenDSS, to help determine origin and active phases
+- Add conversion of OpenDSS PVSystem objects into generators, using KVA for generator limits
 
 ### v0.1.2
 - Add support for network flow approximation formulation, NFAPowerModel

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -416,6 +416,52 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             push!(tppm_data["gen"], genDict)
         end
     end
+
+    if haskey(dss_data, "pvsystem")
+        for pv in dss_data["pvsystem"]
+            if haskey(pv, "like")
+                pv = merge(find_component(dss_data, pv["like"], "pvsystem"), pv)
+            end
+
+            defaults = createPVSystem(pv["bus1"], pv["name"]; to_sym_keys(pv)...)
+
+            pvDict = Dict{String,Any}()
+
+            nconductors = tppm_data["conductors"]
+            name, nodes = parse_busname(defaults["bus1"])
+
+            pvDict["name"] = defaults["name"]
+            pvDict["gen_bus"] = find_bus(name, tppm_data)
+
+            pvDict["pg"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["qg"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["vg"] = PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nconductors))
+
+            pvDict["pmin"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            pvDict["pmax"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+
+            pvDict["qmin"] = -PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["qmax"] =  PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+
+            pvDict["gen_status"] = convert(Int, defaults["enabled"])
+
+            pvDict["model"] = 2
+            pvDict["startup"] = 0.0
+            pvDict["shutdown"] = 0.0
+            pvDict["ncost"] = 3
+            pvDict["cost"] = [0.0, 1.0, 0.0]
+
+            pvDict["index"] = length(tppm_data["gen"]) + 1
+
+            pvDict["active_phases"] = [nodes[n] > 0 ? 1 : 0 for n in 1:nconductors]
+            pvDict["source_id"] = "pvsystem.$(defaults["name"])"
+
+            used = ["name", "phases", "bus1"]
+            PMs.import_remaining!(pvDict, defaults, import_all; exclude=used)
+
+            push!(tppm_data["gen"], pvDict)
+        end
+    end
 end
 
 

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -419,6 +419,8 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
     if haskey(dss_data, "pvsystem")
         for pv in dss_data["pvsystem"]
+            warn(LOGGER, "Converting PVSystem \"$(pv["name"])\" into generator with limits determined by OpenDSS property 'kVA'")
+
             if haskey(pv, "like")
                 pv = merge(find_component(dss_data, pv["like"], "pvsystem"), pv)
             end

--- a/test/data/opendss/case3_balanced_pv.dss
+++ b/test/data/opendss/case3_balanced_pv.dss
@@ -1,0 +1,38 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+New PVSystem.PV1 phases=3 bus1=primary.1.2.3 kv=0.4 kva=25
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/data/opendss/case3_unbalanced_1phase-pv.dss
+++ b/test/data/opendss/case3_unbalanced_1phase-pv.dss
@@ -1,0 +1,36 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=8   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+New PVSystem.PV1 phases=1 bus1=primary.1 kv=0.4 kva=2
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -299,4 +299,15 @@ TESTLOG = getlogger(PowerModels)
         @test sol["status"] == :LocalOptimal
         @test isapprox(sol["objective"], 0.0182769; atol = 1e-4)
     end
+
+    @testset "3-bus balanced pv" begin
+        tppm = TPPMs.parse_file("../test/data/opendss/case3_balanced_pv.dss")
+        sol = TPPMs.run_tp_opf(tppm, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["status"] == :LocalOptimal
+        @test sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]) < 0.0
+        @test sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]) < 0.0
+        @test isapprox(sum(sol["solution"]["gen"]["2"]["pg"] * sol["solution"]["baseMVA"]), 0.018345; atol=1e-4)
+        @test isapprox(sum(sol["solution"]["gen"]["2"]["qg"] * sol["solution"]["baseMVA"]), 0.00919404; atol=1e-4)
+    end
 end

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -301,7 +301,18 @@ TESTLOG = getlogger(PowerModels)
     end
 
     @testset "3-bus balanced pv" begin
+        setlevel!(TESTLOG, "warn")
+        @test_warn(TESTLOG, "Converting PVSystem \"pv1\" into generator with limits determined by OpenDSS property 'kVA'",
+                   TPPMs.parse_file("../test/data/opendss/case3_balanced_pv.dss"))
+        setlevel!(TESTLOG, "error")
+
         tppm = TPPMs.parse_file("../test/data/opendss/case3_balanced_pv.dss")
+
+        @test length(tppm["gen"]) == 2
+        @test all(tppm["gen"]["2"]["qmin"] .== -tppm["gen"]["2"]["qmax"])
+        @test all(tppm["gen"]["2"]["pmax"] .== tppm["gen"]["2"]["qmax"])
+        @test all(tppm["gen"]["2"]["pmin"].values .== 0.0)
+
         sol = TPPMs.run_tp_opf(tppm, PMs.ACPPowerModel, ipopt_solver)
 
         @test sol["status"] == :LocalOptimal
@@ -309,5 +320,18 @@ TESTLOG = getlogger(PowerModels)
         @test sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]) < 0.0
         @test isapprox(sum(sol["solution"]["gen"]["2"]["pg"] * sol["solution"]["baseMVA"]), 0.018345; atol=1e-4)
         @test isapprox(sum(sol["solution"]["gen"]["2"]["qg"] * sol["solution"]["baseMVA"]), 0.00919404; atol=1e-4)
+    end
+
+    @testset "3-bus unbalanced single-phase pv" begin
+        tppm = TPPMs.parse_file("../test/data/opendss/case3_unbalanced_1phase-pv.dss")
+        sol = TPPMs.run_tp_opf(tppm, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["status"] == :LocalOptimal
+
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["pg"] * sol["solution"]["baseMVA"]), 0.0196116; atol=1e-3)
+        @test isapprox(sum(sol["solution"]["gen"]["1"]["qg"] * sol["solution"]["baseMVA"]), 0.00923107; atol=1e-3)
+
+        @test all(sol["solution"]["gen"]["2"]["pg"][2:3] .== 0.0)
+        @test all(sol["solution"]["gen"]["2"]["qg"][2:3] .== 0.0)
     end
 end


### PR DESCRIPTION
Adds a section to the `dss2tppm_gen!` function to parse PVSystem OpenDSS objects into simple generators as a first approximation. Uses exclusively the `kVA` property to determine the generator limits `pmin/pmax` and `qmin/qmax`, i.e. `0/kVA` and `-kVA/kVA`, respectively.

Added unit test assumes more generation than necessary from PV, and therefore power is expected to be injected back into the sourcebus generator (transmission network).

There are several supported OpenDSS properties for PVSystems that might be more appropriate, and I welcome discussion on the best practice to get the closest approximation to what OpenDSS might be doing. 

In particular, `Pmpp` (Power at the max power point, kW @ 1 kW/m2 of irradiation) seems like it might be a better value to determine `pmax`. As a first step I was thinking we could assume default values for `P-Tcurve`, `temperature`, and `irradiation`, (i.e. constant, 25C, and 1, respectively), which are all required values to calculate the output power from the PV array. This seems to make `Pmpp` the hard upper limit on PV generation.

Another comment is that in the current implementation of `dss2tppm_pv!`, the OpenDSS properties of `kW` and `kvar` are utilized, but `kw` is undocumented as an input property (although it is indicated that it is an internal value that can be probed), and `kvar` seems to set the PVSystem into a constant kvar mode. Also, I noted that those values are not divided by `nconductors`, as we have done in the other generator cases. I therefore have some confusion about the current implementation of `pvsystem` parsing. 

CC @frederikgeth @ccoffrin 

Closes #11 