### PR TITLE
ADD: Support for Logging in Julia Standard Library

### DIFF
--- a/src/ThreePhasePowerModels.jl
+++ b/src/ThreePhasePowerModels.jl
@@ -12,13 +12,25 @@ if VERSION < v"0.7.0-"
     import Compat: findall
     import Compat: undef
     import Compat: Nothing
+
+    function __init__()
+        global LOGGER = getlogger(PowerModels)
+    end
+
+    macro warn(message)
+        :(Memento.warn(LOGGER, $(esc(message))))
+    end
+
+    macro debug(message)
+        :(Memento.debug(LOGGER, $(esc(message))))
+    end
+
+    macro info(message)
+        :(Memento.info(LOGGER, $(esc(message))))
+    end
 end
 
 const PMs = PowerModels
-
-function __init__()
-    global LOGGER = getlogger(PowerModels)
-end
 
 include("core/ref.jl")
 include("core/multiconductor.jl")

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -592,7 +592,7 @@ end
 ""
 function add_original_variables(sol, pm::GenericPowerModel)
     if !haskey(pm.setting, "output") || !haskey(pm.setting["output"], "branch_flows") || pm.setting["output"]["branch_flows"] == false
-        error(LOGGER, "deriving the original variables requires setting: branch_flows => true")
+        throw(error("deriving the original variables requires setting: branch_flows => true"))
     end
 
     for (nw, network) in pm.ref[:nw]

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -7,10 +7,10 @@ function parse_file(io::IOStream; import_all::Bool=false, vmin::Float64=0.9, vma
     if endswith(lowercase(strip(io.name,['>'])), ".m")
         tppm_data = ThreePhasePowerModels.parse_matlab(io)
     elseif endswith(lowercase(strip(io.name,['>'])), ".dss")
-        warn(LOGGER, "Not all OpenDSS features are supported, currently only minimal support for lines, loads, generators, and capacitors as shunts. Transformers and reactors as transformer branches are included, but value translation is not fully supported.")
+        @warn "Not all OpenDSS features are supported, currently only minimal support for lines, loads, generators, and capacitors as shunts. Transformers and reactors as transformer branches are included, but value translation is not fully supported."
         tppm_data = ThreePhasePowerModels.parse_opendss(io; import_all=import_all, vmin=vmin, vmax=vmax)
     else
-        error(LOGGER, "only .m and .dss files are supported")
+        throw(error("only .m and .dss files are supported"))
     end
 
     check_network_data(tppm_data)

--- a/src/io/dss_parse.jl
+++ b/src/io/dss_parse.jl
@@ -18,7 +18,7 @@ function parse_rpn(expr::AbstractString, dtype::Type=Float64)
     clean_expr = strip(expr, array_delimiters)
 
     if occursin("rollup", clean_expr) || occursin("rolldn", clean_expr) || occursin("swap", clean_expr)
-        warn(LOGGER, "parse_rpn does not support \"rollup\", \"rolldn\", or \"swap\", leaving as String")
+        @warn "parse_rpn does not support \"rollup\", \"rolldn\", or \"swap\", leaving as String"
         return expr
     end
 
@@ -42,13 +42,13 @@ function parse_rpn(expr::AbstractString, dtype::Type=Float64)
             end
         catch error
             if isa(error, ArgumentError)
-                warn(LOGGER, "\"$expr\" is not valid Reverse Polish Notation, leaving as String")
+                @warn "\"$expr\" is not valid Reverse Polish Notation, leaving as String"
                 return expr
             end
         end
     end
     if length(stack) > 1
-        warn(LOGGER, "\"$expr\" is not valid Reverse Polish Notation, leaving as String")
+        @warn "\"$expr\" is not valid Reverse Polish Notation, leaving as String"
         return expr
     else
         return stack[1]
@@ -76,7 +76,7 @@ function parse_conn(conn::String)::String
     elseif conn in ["delta", "ll"]
         return "delta"
     else
-        warn(LOGGER, "Unsupported connection $conn, defaulting to \"wye\"")
+        @warn "Unsupported connection $conn, defaulting to \"wye\""
         return "wye"
     end
 end
@@ -602,7 +602,7 @@ defined, an empty dictionary will be used. Assumes that unnamed properties are
 given in order, but named properties can be given anywhere.
 """
 function parse_component(component::AbstractString, properties::AbstractString, compDict::Dict=Dict{String,Any}())
-    debug(LOGGER, "Properties: $properties")
+    @debug "Properties: $properties"
     ctype, name = split(component, '.'; limit=2)
 
     if !haskey(compDict, "name")
@@ -610,7 +610,7 @@ function parse_component(component::AbstractString, properties::AbstractString, 
     end
 
     propArray = parse_properties(properties)
-    debug(LOGGER, "propArray: $propArray")
+    @debug "propArray: $propArray"
 
     propNames = get_prop_name(ctype)
     propIdx = 1
@@ -722,7 +722,7 @@ function assign_property!(dss_data::Dict, cType::AbstractString, cName::Abstract
             end
         end
     else
-        warn(LOGGER, "Cannot find $cType object $cName.")
+        @warn "Cannot find $cType object $cName."
     end
 end
 
@@ -737,7 +737,7 @@ Will also parse files defined inside of the originating DSS file via the
 """
 function parse_dss(io::IOStream)::Dict
     filename = match(r"^<file\s(.+)>$", io.name).captures[1]
-    info(LOGGER, "Calling parse_dss on $filename")
+    @info "Calling parse_dss on $filename"
     currentFile = split(filename, "/")[end]
     path = join(split(filename, '/')[1:end-1], '/')
     dss_str = read(open(filename), String)
@@ -755,7 +755,7 @@ function parse_dss(io::IOStream)::Dict
 
     for (n, line) in enumerate(stripped_lines)
         real_line_num = findall(lines .== line)[1]
-        debug(LOGGER, "LINE $real_line_num: $line")
+        @debug "LINE $real_line_num: $line"
         line = strip_comments(line)
 
         if startswith(strip(line), '~')
@@ -772,26 +772,26 @@ function parse_dss(io::IOStream)::Dict
             cmd = lowercase(line_elements[1])
 
             if cmd == "clear"
-                info(LOGGER, "`dss_data` has been reset with the \"clear\" command.")
+                @info "`dss_data` has been reset with the \"clear\" command."
                 dss_data = Dict{String,Array}("filename"=>dss_data["filename"])
                 continue
 
             elseif cmd == "redirect"
                 file = line_elements[2]
                 fullpath = path == "" ? file : join([path, file], '/')
-                info(LOGGER, "Redirecting to file \"$file\"")
+                @info "Redirecting to file \"$file\""
                 merge_dss!(dss_data, parse_dss(fullpath))
                 continue
 
             elseif cmd == "compile"
                 file = split(strip(line_elements[2], ['(',')']), '\\')[end]
                 fullpath = path == "" ? file : join([path, file], '/')
-                info(LOGGER, "Compiling file \"$file\"")
+                @info "Compiling file \"$file\""
                 merge_dss!(dss_data, parse_dss(fullpath))
                 continue
 
             elseif cmd == "set"
-                debug(LOGGER, "set command: $line_elements")
+                @debug "set command: $line_elements"
                 if length(line_elements) == 2
                     property, value = split(lowercase(line_elements[2]), '='; limit=2)
                 else
@@ -808,7 +808,7 @@ function parse_dss(io::IOStream)::Dict
             elseif cmd == "buscoords"
                 file = line_elements[2]
                 fullpath = path == "" ? file : join([path, file], '/')
-                debug(LOGGER, "Buscoords path: $fullpath")
+                @debug "Buscoords path: $fullpath"
                 dss_data["buscoords"] = parse_buscoords(fullpath)
 
             elseif cmd == "new"
@@ -822,11 +822,11 @@ function parse_dss(io::IOStream)::Dict
                         assign_property!(dss_data, cType, cName, propName, propValue)
                     end
                 catch
-                    warn(LOGGER, "Command \"$cmd\" on line $real_line_num in \"$currentFile\" is not supported, skipping.")
+                    @warn "Command \"$cmd\" on line $real_line_num in \"$currentFile\" is not supported, skipping."
                 end
             end
 
-            debug(LOGGER, "size curCompDict: $(length(curCompDict))")
+            @debug "size curCompDict: $(length(curCompDict))"
             if n < nlines && startswith(strip(stripped_lines[n + 1]), '~')
                 continue
             elseif length(curCompDict) > 0
@@ -837,7 +837,7 @@ function parse_dss(io::IOStream)::Dict
         end
     end
 
-    info(LOGGER, "Done parsing $filename")
+    @info "Done parsing $filename"
     return dss_data
 end
 
@@ -875,7 +875,7 @@ function parse_element_with_dtype(dtype, element)
             try
                 out = parse(dtype, element)
             catch
-                warn(LOGGER, "cannot parse $element as $dtype, leaving as String.")
+                @warn "cannot parse $element as $dtype, leaving as String."
                 out = element
             end
         end
@@ -894,12 +894,12 @@ the default properties from the `get_prop_default` function.
 function parse_dss_with_dtypes!(dss_data::Dict, toParse::Array{String}=[])
     for compType in toParse
         if haskey(dss_data, compType)
-            debug(LOGGER, "type: $compType")
+            @debug "type: $compType"
             for item in dss_data[compType]
                 dtypes = get_dtypes(compType)
                 for (k, v) in item
                     if haskey(dtypes, k)
-                        debug(LOGGER, "key: $k")
+                        @debug "key: $k"
                         if isa(v, Array)
                             arrout = []
                             for el in v
@@ -913,7 +913,7 @@ function parse_dss_with_dtypes!(dss_data::Dict, toParse::Array{String}=[])
                         elseif isa(v, AbstractString)
                             item[k] = parse_element_with_dtype(dtypes[k], v)
                         else
-                            error(LOGGER, "dtype unknown $compType, $k, $v")
+                            throw(error("dtype unknown $compType, $k, $v"))
                         end
                     end
                 end

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -187,7 +187,7 @@ function createLine(bus1, bus2, name::AbstractString; kwargs...)
     len = get(kwargs, :length, 1.0) * to_meters[units]
 
     if haskey(kwargs, :rg)
-        warn(LOGGER, "Rg,Xg are not fully supported")
+        @warn "Rg,Xg are not fully supported"
     end
 
     rmatrix .+= rg * (freq/basefreq - 1.0)
@@ -942,7 +942,7 @@ function createPVSystem(bus1, name::AbstractString; kwargs...)
     end
 
     if haskey(kwargs, :like)
-        warn(LOGGER, "\"like\" keyword on pvsystem $name is not supported.")
+        @warn "\"like\" keyword on pvsystem $name is not supported."
     end
 
     pvsystem = Dict{String,Any}("name" => name,

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -110,7 +110,7 @@ function parse_matlab_string(data_string::String)
     if haskey(matlab_data, "tppmc.version")
         case["source_version"] = VersionNumber(matlab_data["tppmc.version"])
     else
-        warn(LOGGER, "No version number found, file may not be compatible with parser.")
+        @warn "No version number found, file may not be compatible with parser."
         case["source_version"] = v"0"
     end
 
@@ -137,7 +137,7 @@ function parse_matlab_string(data_string::String)
         end
         case["bus"] = buses
     else
-        error(string("no bus table found in matlab file.  The file seems to be missing \"tppmc.bus = [...];\""))
+        throw(error(string("no bus table found in matlab file.  The file seems to be missing \"tppmc.bus = [...];\"")))
     end
 
     if haskey(matlab_data, "tppmc.load")
@@ -149,7 +149,7 @@ function parse_matlab_string(data_string::String)
         end
         case["load"] = loads
     else
-        error(string("no load table found in matlab file.  The file seems to be missing \"tppmc.load = [...];\""))
+        throw(error(string("no load table found in matlab file.  The file seems to be missing \"tppmc.load = [...];\"")))
     end
 
     if haskey(matlab_data, "tppmc.shunt")
@@ -171,7 +171,7 @@ function parse_matlab_string(data_string::String)
         end
         case["gen"] = gens
     else
-        error(string("no gen table found in matlab file.  The file seems to be missing \"tppmc.gen = [...];\""))
+        throw(error(string("no gen table found in matlab file.  The file seems to be missing \"tppmc.gen = [...];\"")))
     end
 
     if haskey(matlab_data, "tppmc.branch")
@@ -183,7 +183,7 @@ function parse_matlab_string(data_string::String)
         end
         case["branch"] = branches
     else
-        error(string("no branch table found in matlab file.  The file seems to be missing \"tppmc.branch = [...];\""))
+        throw(error(string("no branch table found in matlab file.  The file seems to be missing \"tppmc.branch = [...];\"")))
     end
 
 
@@ -197,7 +197,7 @@ function parse_matlab_string(data_string::String)
         case["bus_name"] = bus_names
 
         if length(case["bus_name"]) != length(case["bus"])
-            error("incorrect Matpower file, the number of bus names ($(length(case["bus_name"]))) is inconsistent with the number of buses ($(length(case["bus"]))).\n")
+            throw(error("incorrect Matpower file, the number of bus names ($(length(case["bus_name"]))) is inconsistent with the number of buses ($(length(case["bus"]))).\n"))
         end
     end
 
@@ -211,7 +211,7 @@ function parse_matlab_string(data_string::String)
         case["gencost"] = gencost
 
         if length(case["gencost"]) != length(case["gen"])
-            error("incorrect matlab file, the number of generator cost functions ($(length(case["gencost"]))) is inconsistent with the number of generators ($(length(case["gen"]))).\n")
+            throw(error("incorrect matlab file, the number of generator cost functions ($(length(case["gencost"]))) is inconsistent with the number of generators ($(length(case["gen"]))).\n"))
         end
     end
 
@@ -231,10 +231,10 @@ function parse_matlab_string(data_string::String)
                     push!(tbl, row_data)
                 end
                 case[case_name] = tbl
-                info(LOGGER, "extending matlab format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
+                @info "extending matlab format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)"
             else
                 case[case_name] = value
-                info(LOGGER, "extending matlab format with constant data: $(case_name)")
+                @info "extending matlab format with constant data: $(case_name)"
             end
         end
     end
@@ -252,7 +252,7 @@ function translate_version!(ml_data::Dict{String,Any})
     if ml_data["source_version"] == current_version
         return ml_data
     else
-        warn(LOGGER, "matlab source data has unrecognized version $(ml_data["source_version"]), cannot translate to version $current_version, parse may be invalid")
+        @warn "matlab source data has unrecognized version $(ml_data["source_version"]), cannot translate to version $current_version, parse may be invalid"
         return ml_data
     end
 end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -90,7 +90,7 @@ function discover_buses(dss_data::Dict)::Array
         end
     end
     if length(buses) == 0
-        error(LOGGER, "dss_data has no branches!")
+        throw(error("dss_data has no branches!"))
     else
         return buses
     end
@@ -150,7 +150,7 @@ function find_component(data::Dict, name::AbstractString, compType::AbstractStri
             return comp
         end
     end
-    warn(LOGGER, "Could not find $compType \"$name\"")
+    @warn "Could not find $compType \"$name\""
     return Dict{String,Any}()
 end
 
@@ -165,7 +165,7 @@ function find_bus(busname::AbstractString, tppm_data::Dict)
     if haskey(bus, "bus_i")
         return bus["bus_i"]
     else
-        error(LOGGER, "cannot find connected bus with id \"$busname\"")
+        throw(error("cannot find connected bus with id \"$busname\""))
     end
 end
 
@@ -196,7 +196,7 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             kv = defaults["kv"]
             expected_kv = tppm_data["basekv"] / sqrt(tppm_data["conductors"])
             if !isapprox(kv, expected_kv; atol=expected_kv * 0.01)
-                warn(LOGGER, "Load has kv=$kv, not the expected kv=$(expected_kv). Results may not match OpenDSS")
+                @warn "Load has kv=$kv, not the expected kv=$(expected_kv). Results may not match OpenDSS"
             end
 
             loadDict["name"] = defaults["name"]
@@ -419,7 +419,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
     if haskey(dss_data, "pvsystem")
         for pv in dss_data["pvsystem"]
-            warn(LOGGER, "Converting PVSystem \"$(pv["name"])\" into generator with limits determined by OpenDSS property 'kVA'")
+            @warn "Converting PVSystem \"$(pv["name"])\" into generator with limits determined by OpenDSS property 'kVA'"
 
             if haskey(pv, "like")
                 pv = merge(find_component(dss_data, pv["like"], "pvsystem"), pv)
@@ -493,7 +493,7 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             merge!(line, linecode)
 
             if haskey(line, "basefreq") && line["basefreq"] != tppm_data["basefreq"]
-                warn(LOGGER, "basefreq=$(line["basefreq"]) on line $(line["name"]) does not match circuit basefreq=$(tppm_data["basefreq"])")
+                @warn "basefreq=$(line["basefreq"]) on line $(line["name"]) does not match circuit basefreq=$(tppm_data["basefreq"])"
                 line["freq"] = deepcopy(line["basefreq"])
                 line["basefreq"] = deepcopy(tppm_data["basefreq"])
             end
@@ -527,7 +527,7 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             branchDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             if !isdiag(cmatrix)
-                info(LOGGER, "Only diagonal elements of cmatrix are used to obtain branch values `b_fr/to`")
+                @info "Only diagonal elements of cmatrix are used to obtain branch values `b_fr/to`"
             end
             branchDict["b_fr"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["basefreq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
             branchDict["b_to"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["basefreq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
@@ -574,7 +574,7 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
     end
 
     if haskey(dss_data, "transformer")
-        warn(LOGGER, "transformers are not yet supported, treating like non-transformer lines")
+        @warn "transformers are not yet supported, treating like non-transformer lines"
         for transformer in dss_data["transformer"]
             if haskey(transformer, "like")
                 transformer = merge(find_component(dss_data, transformer["like"], "transformer"), transformer)
@@ -630,7 +630,7 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
 
                 push!(tppm_data["branch"], transDict)
             else
-                warn(LOGGER, "3-winding transformers are not yet supported, treating like two non-transformer lines connected through a starbus")
+                @warn "3-winding transformers are not yet supported, treating like two non-transformer lines connected through a starbus"
 
                 starbus = create_starbus(tppm_data, defaults)
                 push!(tppm_data["bus"], starbus)
@@ -687,7 +687,7 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
     end
 
     if haskey(dss_data, "reactor")
-        warn(LOGGER, "reactors as constant impedance elements is not yet supported, treating like line")
+        @warn "reactors as constant impedance elements is not yet supported, treating like line"
         for reactor in dss_data["reactor"]
             if haskey(reactor, "bus2")
                 if haskey(reactor, "like")
@@ -908,7 +908,7 @@ function parse_options(options)
     end
 
     if !haskey(options, "defaultbasefreq")
-        warn(LOGGER, "defaultbasefreq is not defined, default for circuit set to 60 Hz")
+        @warn "defaultbasefreq is not defined, default for circuit set to 60 Hz"
         out["defaultbasefreq"] = 60.0
     else
         out["defaultbasefreq"] = parse(Float64, options["defaultbasefreq"])
@@ -953,7 +953,7 @@ function parse_opendss(dss_data::Dict; import_all::Bool=false, vmin::Float64=0.9
         tppm_data["pu"] = defaults["pu"]
         tppm_data["conductors"] = defaults["phases"]
     else
-        error(LOGGER, "Circuit not defined, not a valid circuit!")
+        throw(error("Circuit not defined, not a valid circuit!"))
     end
 
     dss2tppm_bus!(tppm_data, dss_data, import_all, vmin, vmax)

--- a/src/prob/tp_pf_bf.jl
+++ b/src/prob/tp_pf_bf.jl
@@ -3,7 +3,7 @@ export run_tp_pf_bf
 ""
 function run_tp_pf_bf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
     if model_constructor != SDPUBFPowerModel && model_constructor != SOCNLPUBFPowerModel && model_constructor != SOCConicUBFPowerModel && model_constructor != LPUBFPowerModel && model_constructor != LPdiagUBFPowerModel && model_constructor !=  SOCBFPowerModel
-        error(LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
+        throw(error("The problem type tp_opf_bf at the moment only supports a limited set of formulations"))
     end
     return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
@@ -12,7 +12,7 @@ end
 ""
 function run_tp_pf_bf(file::String, model_constructor, solver; kwargs...)
     if model_constructor != SDPUBFPowerModel && model_constructor != SOCNLPUBFPowerModel && model_constructor != SOCConicUBFPowerModel && model_constructor != LPUBFPowerModel && model_constructor !=  SOCBFPowerModel
-        error(LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
+        throw(error("The problem type tp_opf_bf at the moment only supports a limited set of formulations"))
     end
     data = ThreePhasePowerModels.parse_file(file)
     return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)

--- a/test/matlab.jl
+++ b/test/matlab.jl
@@ -1,5 +1,3 @@
-TESTLOG = getlogger(PowerModels)
-
 @testset "test matlab data parser" begin
     @testset "5-bus minimal data" begin
         data = ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_a.m")
@@ -33,15 +31,22 @@ TESTLOG = getlogger(PowerModels)
 
     #=
     @testset "version warning" begin
-        setlevel!(TESTLOG, "warn")
+        if VERSION < v"0.7.0-"
+            setlevel!(TESTLOG, "warn")
 
-        @test_warn(TESTLOG, "matlab source data has unrecognized version 0.0.0, cannot translate to version 1.0.0, parse may be invalid",
-                   ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_b.m"))
+            @test_warn(TESTLOG, "matlab source data has unrecognized version 0.0.0, cannot translate to version 1.0.0, parse may be invalid",
+                    ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_b.m"))
 
-        @test_warn(TESTLOG, "No version number found, file may not be compatible with parser.",
-                   ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_b.m"))
+            @test_warn(TESTLOG, "No version number found, file may not be compatible with parser.",
+                    ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_b.m"))
 
-        setlevel!(TESTLOG, "error")
+            setlevel!(TESTLOG, "error")
+        else
+            Logging.disable_logging(Logging.Info)
+            @test_logs (:warm, "matlab source data has unrecognized version 0.0.0, cannot translate to version 1.0.0, parse may be invalid" ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_b.m")
+            @test_logs (:warn, "No version number found, file may not be compatible with parser.") ThreePhasePowerModels.parse_file("../test/data/matlab/case5_i_r_b.m")
+            Logging.disable_logging(Logging.Warn)
+        end
     end
     =#
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,13 +3,22 @@ const TPPMs = ThreePhasePowerModels
 
 using Memento
 
+if VERSION < v"0.7.0-"
+    setlevel!(getlogger(PowerModels), "error")
+
+    macro test_logs(exs...)
+    end
+else
+    using Test
+    using Logging
+    Logging.disable_logging(LogLevel(Logging.Warn))
+end
+
 using InfrastructureModels
 
 using PowerModels
 const PMs = PowerModels
 
-# Suppress warnings during testing.
-setlevel!(getlogger(PowerModels), "error")
 
 using Ipopt
 using Cbc


### PR DESCRIPTION
Adds support for the Logging library within Julia v0.7/v1.0's standard
library. Support for Memento will be maintained until Julia v0.6 support
is dropped, due to no logging available in the Base before Julia v0.7.
Removal of Memento has been made easier by separating Memento-
based tests into their own blocks, and by creating temporary macros
upon load of ThreePhasePowerModels in VERSION < v"0.7.0-".

All unit tests were converted, no unit tests were dropped in this
addition.

TODO:

- [ ] Package-level logging (separate logger for package)