### PR TITLE
zero series impedance branches

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -35,25 +35,31 @@ end
 
 
 ""
-function constraint_ohms_tp_yt_from(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function constraint_ohms_tp_yt_from(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd, atol_impzero=1E-13)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
 
-    g, b = PMs.calc_branch_y(branch)
     tr, ti = PMs.calc_branch_t(branch)
     g_fr = branch["g_fr"]
     b_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    constraint_ohms_tp_yt_from(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
+    if all(abs.(branch["br_r"]).<=atol_impzero) && all(abs.(branch["br_x"]).<=atol_impzero)
+        g_to = branch["g_to"]
+        b_to = branch["b_to"]
+        constraint_ohms_tp_yt_from_impzero(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm)
+    else
+        g, b = PMs.calc_branch_y(branch)
+        constraint_ohms_tp_yt_from(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
+    end
 end
 
 
 ""
-function constraint_ohms_tp_yt_to(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function constraint_ohms_tp_yt_to(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd, atol_impzero=1E-13)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -66,7 +72,12 @@ function constraint_ohms_tp_yt_to(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw,
     b_to = branch["b_to"]
     tm = branch["tap"]
 
-    constraint_ohms_tp_yt_to(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
+    if all(abs.(branch["br_r"]).<=atol_impzero) && all(abs.(branch["br_x"]).<=atol_impzero)
+        # do nothing, constraint_ohms_tp_yt_from_impzero covers both sides
+    else
+        g, b = PMs.calc_branch_y(branch)
+        constraint_ohms_tp_yt_to(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
+    end
 end
 
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -52,7 +52,7 @@ end
 
 
 """
-Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
+Creates Ohms constraints for zero series impedance branches
 
 ```
 p[f_idx] - g_fr/tm*v[f_bus]^2 + p[t_idx] - g_to*v[t_bus]^2 == 0

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -55,6 +55,27 @@ end
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 
 ```
+p[f_idx] - g_fr/tm*v[f_bus]^2 + p[t_idx] - g_to*v[t_bus]^2 == 0
+q[f_idx] + b_fr/tm*v[f_bus]^2 + q[t_idx] + b_to*v[t_bus]^2 == 0
+"""
+function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
+    p_fr  = var(pm, n, c,  :p, f_idx)
+    p_to  = var(pm, n, c,  :p, t_idx)
+    q_fr  = var(pm, n, c,  :q, f_idx)
+    q_to  = var(pm, n, c,  :q, t_idx)
+    vm_fr = [var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
+    vm_to = [var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+
+    @NLconstraint(pm.model, p_fr - g_fr[c]*vm_fr[c]^2 + p_to - g_to[c]*vm_to[c]^2 == 0)
+    @NLconstraint(pm.model, q_fr + b_fr[c]*vm_fr[c]^2 + q_to + b_to[c]*vm_to[c]^2 == 0)
+end
+
+"""
+Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
+
+```
 p[t_idx] ==  (g+g_to)*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[f_bus])) + (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -57,6 +57,8 @@ Creates Ohms constraints for zero series impedance branches
 ```
 p[f_idx] - g_fr/tm*v[f_bus]^2 + p[t_idx] - g_to*v[t_bus]^2 == 0
 q[f_idx] + b_fr/tm*v[f_bus]^2 + q[t_idx] + b_to*v[t_bus]^2 == 0
+vm_fr[c] == vm_to[c]
+va_fr[c] == va_to[c]
 """
 function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
     p_fr  = var(pm, n, c,  :p, f_idx)
@@ -70,6 +72,9 @@ function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c:
 
     @NLconstraint(pm.model, p_fr - g_fr[c]*vm_fr[c]^2 + p_to - g_to[c]*vm_to[c]^2 == 0)
     @NLconstraint(pm.model, q_fr + b_fr[c]*vm_fr[c]^2 + q_to + b_to[c]*vm_to[c]^2 == 0)
+    # link the voltages on both sides
+    @constraint(pm.model, vm_fr[c] == vm_to[c])
+    @constraint(pm.model, va_fr[c] == va_to[c])
 end
 
 """

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -22,6 +22,21 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
     # omit reactive constraint
 end
 
+"""
+Creates Ohms constraints for zero impedance branches
+
+```
+p[f_idx] + p[t_idx] == 0
+```
+"""
+function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractDCPForm
+    va_fr = [var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
+    va_to = [var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+    # p[f_idx] + p[t_idx] == 0
+    # this is already implied by construction of p[t_idx]
+    # set zero angle difference:
+    @constraint(pm.model, va_fr[c] == va_to[c])
+end
 
 "Do nothing, this model is symmetric"
 function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractDCPForm
@@ -70,4 +85,3 @@ end
 "nothing to do, this model is symmetric"
 function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.NFAForm
 end
-

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -23,7 +23,7 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
 end
 
 """
-Creates Ohms constraints for zero impedance branches
+Creates Ohms constraints for zero series impedance branches
 
 ```
 p[f_idx] + p[t_idx] == 0

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -42,23 +42,6 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
 end
 
 """
-Creates Ohms constraints for zero series impedance branches
-"""
-function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms
-    p_fr = var(pm, n, c, :p, f_idx)
-    p_to = var(pm, n, c, :p, t_idx)
-    q_fr = var(pm, n, c, :q, f_idx)
-    q_to = var(pm, n, c, :q, t_idx)
-    w    = var(pm, n, :w)
-    wr   = var(pm, n, :wr)
-    wi   = var(pm, n, :wi)
-
-    @constraint(pm.model, p_fr - g_fr[c]*w[(f_bus, c)] + p_to - g_to[c]*w[(t_bus, c)] == 0)
-    @constraint(pm.model, q_fr + b_fr[c]*w[(f_bus, c)] + q_to + b_to[c]*w[(t_bus, c)] == 0)
-end
-
-
-"""
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
 function constraint_ohms_tp_yt_to(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -42,7 +42,7 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
 end
 
 """
-Creates Ohms constraints for zero series impedance
+Creates Ohms constraints for zero series impedance branches
 """
 function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms
     p_fr = var(pm, n, c, :p, f_idx)

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -41,6 +41,22 @@ function constraint_ohms_tp_yt_from(pm::GenericPowerModel{T}, n::Int, c::Int, f_
                                      g[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
 end
 
+"""
+Creates Ohms constraints for zero series impedance
+"""
+function constraint_ohms_tp_yt_from_impzero(pm::GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms
+    p_fr = var(pm, n, c, :p, f_idx)
+    p_to = var(pm, n, c, :p, t_idx)
+    q_fr = var(pm, n, c, :q, f_idx)
+    q_to = var(pm, n, c, :q, t_idx)
+    w    = var(pm, n, :w)
+    wr   = var(pm, n, :wr)
+    wi   = var(pm, n, :wi)
+
+    @constraint(pm.model, p_fr - g_fr[c]*w[(f_bus, c)] + p_to - g_to[c]*w[(t_bus, c)] == 0)
+    @constraint(pm.model, q_fr + b_fr[c]*w[(f_bus, c)] + q_to + b_to[c]*w[(t_bus, c)] == 0)
+end
+
 
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)

--- a/test/data/opendss/case2_diag_impzero.dss
+++ b/test/data/opendss/case2_diag_impzero.dss
@@ -1,0 +1,35 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50 ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.000    0.1000 |  0.000    0.000    0.1000)
+~ xmatrix = ( 0.1 |  0.0    0.1 | 0.0    0.0    0.1)
+~ cmatrix = ( 0  | -0  0 | -0 -0 0  ) ! small capacitance
+
+New linecode.impzero nphases=3 basefreq=50 ! ohms per 5 mile
+~ rmatrix = ( 1E-14 | 0.000    1E-14 |  0.000    0.000    1E-14)
+~ xmatrix = ( 1E-14 |  0.0    1E-14 | 0.0    0.0    1E-14)
+~ cmatrix = ( 0  | -0  0 | -0 -0 0  ) ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Intm.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.impzero  bus1=Intm.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+
+!Loads - single phase
+
+New Load.L1 phases=1  Primary.1.0   0.23   kW=6   kvar=0  model=1
+New Load.L2 phases=1  Primary.2.0   0.23   kW=6   kvar=0  model=1
+New Load.L3 phases=1  Primary.3.0   0.23   kW=6   kvar=0  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+Calcvoltagebases
+
+Solve

--- a/test/data/opendss/case2_diag_impzero.dss
+++ b/test/data/opendss/case2_diag_impzero.dss
@@ -18,8 +18,8 @@ New linecode.impzero nphases=3 basefreq=50 ! ohms per 5 mile
 
 !Define lines
 
-New Line.OHLine  bus1=sourcebus.1.2.3.0  Intm.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
-New Line.impzero  bus1=Intm.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.impzero  bus1=sourcebus.1.2.3.0  Intm.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.OHLine  bus1=Intm.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
 
 !Loads - single phase
 

--- a/test/data/opendss/case3_unbalanced_impzero.dss
+++ b/test/data/opendss/case3_unbalanced_impzero.dss
@@ -1,0 +1,43 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6 basemva=0.5
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (0.0  | 0.0  0.0 | 0.0 0.0 0.0  )  ! small capacitance
+
+! move capacitor in new line with (close to) zero series impedance
+New linecode.impzero nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.0 | 0.0    0.0 |  1E-14    0.0    0.0)
+~ xmatrix = ( 1E-14 |  1E-14    0.0 | 0.0    0.0    0.0)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  Intm.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+New Line.impzero    Bus1=Intm.1.2.3.0  loadbus.1.2.3.0  linecode = impzero  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=9   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/data/opendss/case3_unbalanced_impzero.dss
+++ b/test/data/opendss/case3_unbalanced_impzero.dss
@@ -5,6 +5,11 @@ New Circuit.3Bus_example
 
 !Define Linecodes
 
+! move capacitor in new line with (close to) zero series impedance
+New linecode.impzero nphases=3 basefreq=50
+~ rmatrix = ( 0.0 | 0.0    0.0 |  1E-14    0.0    0.0)
+~ xmatrix = ( 1E-14 |  1E-14    0.0 | 0.0    0.0    0.0)
+~ cmatrix = (0.0  | -0  0.0 | -0 -0 0.0  )
 
 New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
 ~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
@@ -14,19 +19,13 @@ New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
 New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
 ~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
 ~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
-~ cmatrix = (0.0  | 0.0  0.0 | 0.0 0.0 0.0  )  ! small capacitance
-
-! move capacitor in new line with (close to) zero series impedance
-New linecode.impzero nphases=3 basefreq=50  ! ohms per 5 mile
-~ rmatrix = ( 0.0 | 0.0    0.0 |  1E-14    0.0    0.0)
-~ xmatrix = ( 1E-14 |  1E-14    0.0 | 0.0    0.0    0.0)
 ~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
 
 !Define lines
 
-New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
-New Line.Quad    Bus1=Primary.1.2.3.0  Intm.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
-New Line.impzero    Bus1=Intm.1.2.3.0  loadbus.1.2.3.0  linecode = impzero  length=1   ! 100 ft
+New Line.impzero    Bus1=sourcebus.1.2.3.0  Intm.1.2.3.0  linecode = impzero  length=1   ! 100 ft
+New Line.OHLine  bus1=Intm.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
 
 !Loads - single phase
 

--- a/test/tp_opf.jl
+++ b/test/tp_opf.jl
@@ -356,12 +356,6 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0.0214811; atol = 1e-4)
     end
-    @testset "wr case" begin
-        tppm_data = TPPMs.parse_file("../test/data/opendss/case3_unbalanced_impzero.dss")
-        result = TPPMs.run_tp_opf(tppm_data, PMs.SOCWRPowerModel, ipopt_solver)
-        @test result["status"] == :LocalOptimal
-        @test isapprox(result["objective"], -2.85166366; atol = 1e-5)
-    end
     @testset "dc case" begin
         tppm_data = TPPMs.parse_file("../test/data/opendss/case2_diag_impzero.dss")
         result = TPPMs.run_tp_opf(tppm_data, PMs.DCPPowerModel, ipopt_solver)

--- a/test/tp_opf.jl
+++ b/test/tp_opf.jl
@@ -347,3 +347,25 @@ end
         @test isapprox(result["objective"], 0.0597016; atol = 1e-4)
     end
 end
+
+@testset "zero impedance branch model" begin
+    # ensure that adding a zero impedance branch does not affect the outcome
+    @testset "ac case" begin
+        tppm_data = TPPMs.parse_file("../test/data/opendss/case3_unbalanced_impzero.dss")
+        result = TPPMs.run_tp_opf(tppm_data, PMs.ACPPowerModel, ipopt_solver)
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 0.0214811; atol = 1e-4)
+    end
+    @testset "wr case" begin
+        tppm_data = TPPMs.parse_file("../test/data/opendss/case3_unbalanced_impzero.dss")
+        result = TPPMs.run_tp_opf(tppm_data, PMs.SOCWRPowerModel, ipopt_solver)
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], -2.85166366; atol = 1e-5)
+    end
+    @testset "dc case" begin
+        tppm_data = TPPMs.parse_file("../test/data/opendss/case2_diag_impzero.dss")
+        result = TPPMs.run_tp_opf(tppm_data, PMs.DCPPowerModel, ipopt_solver)
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 0.018000000; atol = 1e-5)
+    end
+end


### PR DESCRIPTION
The transformer loss model is easier to implement if pi-sections with zero series impedance are supported (which are still allowed to contain shunts, and are therefore not lossless). 

In the constraint template of constraint_ohms_tp_yt_from (and to), I check whether all elements of the series impedance are below a threshold (default 1E-13). This threshold is needed when the impedance matrix is calculated from symmetrical components. This transformation introduces some numerical errors, causing a branch with exactly zero impedance in series components, to have small impedance values in the abc frame (in the order of 1E-14).

If all impedance values are below this threshold, a new constraint is applied, constraint_ohms_tp_yt_from_impzero.

I also added two unit tests for different formulations. They check whether the objective value remains the same after adding a zero impedance branch to the network.