### PR TITLE
capacitor bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ThreePhasePowerModels.jl Change Log
 ### staged
 - Allow for arbitrarily named sourcebus
 - Add json parser
+- Fix bug in OpenDSS parse of Capacitors [zbase factor and wrong sign] (#138)
 
 ### v0.3.0
 - Update to JuMP v0.19/MathOptInterface

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -243,7 +243,9 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             name, nodes = parse_busname(defaults["bus1"])
 
             Zbase = (tppm_data["basekv"] / sqrt(3.0))^2 * nconductors / tppm_data["baseMVA"]  # Use single-phase base impedance for each phase
-            Gcap = -Zbase * sum(defaults["kvar"]) / (nconductors * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
+            Zbase = Zbase/3 # use three-phase base impedance, mirroring change in branch
+            # should be  positive; the capacitor power reference has generator convention, not load
+            Gcap = Zbase * sum(defaults["kvar"]) / (nconductors * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
 
             shuntDict["shunt_bus"] = find_bus(name, tppm_data)
             shuntDict["name"] = defaults["name"]

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -243,10 +243,12 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             name, nodes = parse_busname(defaults["bus1"])
 
             Zbase = (tppm_data["basekv"] / sqrt(3.0))^2 * nconductors / tppm_data["baseMVA"]  # Use single-phase base impedance for each phase
-            Zbase = Zbase/3 # use three-phase base impedance, mirroring change in branch
+            # should be in 1MW Sbase, because make_per_unit will rescale to real power base later on already
+            # also, we want the total Sbase, not per phase
+            Zbase = Zbase*tppm_data["baseMVA"]/3
             # should be  positive; the capacitor power reference has generator convention, not load
             Gcap = Zbase * sum(defaults["kvar"]) / (nconductors * 1e3 * (tppm_data["basekv"] / sqrt(3.0))^2)
-
+            
             shuntDict["shunt_bus"] = find_bus(name, tppm_data)
             shuntDict["name"] = defaults["name"]
             shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:

--- a/test/data/opendss/case3_balanced_cap.dss
+++ b/test/data/opendss/case3_balanced_cap.dss
@@ -1,0 +1,38 @@
+Clear
+New Circuit.3Bus_example
+!  define a really stiff source
+~ basekv=0.4   pu=0.9959  MVAsc1=1e6  MVAsc3=1e6
+
+!Define Linecodes
+
+
+New linecode.556MCM nphases=3 basefreq=50  ! ohms per 5 mile
+~ rmatrix = ( 0.1000 | 0.0400    0.1000 |  0.0400    0.0400    0.1000)
+~ xmatrix = ( 0.0583 |  0.0233    0.0583 | 0.0233    0.0233    0.0583)
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  ) ! small capacitance
+
+
+New linecode.4/0QUAD nphases=3 basefreq=50  ! ohms per 100ft
+~ rmatrix = ( 0.1167 | 0.0467    0.1167 | 0.0467    0.0467    0.1167)
+~ xmatrix = (0.0667  |  0.0267    0.0667  |  0.0267    0.0267    0.0667 )
+~ cmatrix = (50.92958178940651  | -0  50.92958178940651 | -0 -0 50.92958178940651  )  ! small capacitance
+
+!Define lines
+
+New Line.OHLine  bus1=sourcebus.1.2.3.0  Primary.1.2.3.0  linecode = 556MCM   length=1  ! 5 mile line
+New Line.Quad    Bus1=Primary.1.2.3.0  loadbus.1.2.3.0  linecode = 4/0QUAD  length=1   ! 100 ft
+
+!Loads - single phase
+
+New Load.L1 phases=1  loadbus.1.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L2 phases=1  loadbus.2.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+New Load.L3 phases=1  loadbus.3.0   ( 0.4 3 sqrt / )   kW=6   kvar=3  model=1
+
+New Capacitor.C1 Bus1=loadbus Phases=3 kVAR=20 kv=0.4
+
+Set voltagebases=[0.4]
+Set tolerance=0.000001
+set defaultbasefreq=50
+Calcvoltagebases
+
+Solve

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -370,4 +370,16 @@
         @test all(sol["solution"]["gen"]["2"]["pg"][2:3] .== 0.0)
         @test all(sol["solution"]["gen"]["2"]["qg"][2:3] .== 0.0)
     end
+
+    @testset "3-bus balanced capacitor" begin
+        tppm = TPPMs.parse_file("../test/data/opendss/case3_balanced_cap.dss")
+        sol = TPPMs.run_tp_pf(tppm, PMs.ACPPowerModel, ipopt_solver)
+
+        @test sol["status"] == :LocalOptimal
+
+        for c in 1:3
+            @test abs(sol["solution"]["bus"]["3"]["vm"][c]-0.98588)<=1E-4
+            @test abs(sol["solution"]["bus"]["2"]["vm"][c]-0.99127)<=1E-4
+        end
+    end
 end

--- a/test/tp_opf.jl
+++ b/test/tp_opf.jl
@@ -250,11 +250,11 @@ end
 
         @test isapprox(result["solution"]["gen"]["1"]["pg"][1], 0.00015236280779412599; atol = 1e-7)
         @test isapprox(result["solution"]["gen"]["1"]["pg"][2], 0.00019836795302238667; atol = 1e-7)
-        @test isapprox(result["solution"]["gen"]["1"]["pg"][3], 0.0002462858630022115; atol = 1e-7)
+        @test isapprox(result["solution"]["gen"]["1"]["pg"][3], 0.0002469182092574594; atol = 1e-7)
 
         @test isapprox(result["solution"]["bus"]["2"]["vm"][1], 0.9736211293005391; atol = 1e-4)
         @test isapprox(result["solution"]["bus"]["2"]["vm"][2], 0.9650040745702724; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["2"]["vm"][3], 0.9560168246207609; atol = 1e-4)
+        @test isapprox(result["solution"]["bus"]["2"]["vm"][3], 0.9562171321941326; atol = 1e-4)
     end
 
     @testset "5-bus 3-phase ac rectangular opf case" begin
@@ -266,11 +266,11 @@ end
 
         @test isapprox(result["solution"]["gen"]["1"]["pg"][1], 0.00015236280779412599; atol = 1e-7)
         @test isapprox(result["solution"]["gen"]["1"]["pg"][2], 0.00019836795302238667; atol = 1e-7)
-        @test isapprox(result["solution"]["gen"]["1"]["pg"][3], 0.0002462858630022115; atol = 1e-7)
+        @test isapprox(result["solution"]["gen"]["1"]["pg"][3], 0.00024691804721165244; atol = 1e-7)
 
         @test isapprox(result["solution"]["bus"]["2"]["vm"][1], 0.9736211293005391; atol = 1e-4)
         @test isapprox(result["solution"]["bus"]["2"]["vm"][2], 0.9650040745702724; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["2"]["vm"][3], 0.9560168246207609; atol = 1e-4)
+        @test isapprox(result["solution"]["bus"]["2"]["vm"][3], 0.9562166511182492; atol = 1e-4)
     end
 
 


### PR DESCRIPTION
Currently there are two bugs in the parsing of capacitors
- The base should be adjusted as before
- The sign is wrong. The power reference in OpenDSS is expressed in generator sign convention, but the parser  assumes load convention. This can be seen by observing that a capacitor creates a voltage drop instead of a voltage rise.

A unit test will follow later, as part of the matrix line charging parameters.