### PR TITLE
FIX: Arbitrary sourcebus names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ ThreePhasePowerModels.jl Change Log
 ===================================
 
 ### staged
-- nothing
+- Allow for arbitrarily named sourcebus
 
 ### v0.3.0
 - Update to JuMP v0.19/MathOptInterface

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -108,7 +108,7 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
     end
 
     buses = discover_buses(dss_data)
-    circuit = createVSource(dss_data["circuit"][1]["bus1"], dss_data["circuit"][1]["name"]; to_sym_keys(dss_data["circuit"][1])...)
+    circuit = createVSource(get(dss_data["circuit"][1], "bus1", "sourcebus"), dss_data["circuit"][1]["name"]; to_sym_keys(dss_data["circuit"][1])...)
     sourcebus = circuit["bus1"]
 
     for (n, (bus, nodes)) in enumerate(buses)

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -108,22 +108,23 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
     end
 
     buses = discover_buses(dss_data)
-    circuit = createVSource("", dss_data["circuit"][1]["name"]; to_sym_keys(dss_data["circuit"][1])...)
+    circuit = createVSource(dss_data["circuit"][1]["bus1"], dss_data["circuit"][1]["name"]; to_sym_keys(dss_data["circuit"][1])...)
+    sourcebus = circuit["bus1"]
 
     for (n, (bus, nodes)) in enumerate(buses)
         busDict = Dict{String,Any}()
 
         nconductors = tppm_data["conductors"]
-        ph1_ang = bus == "sourcebus" ? circuit["angle"] : 0.0
-        vm = bus == "sourcebus" ? circuit["pu"] : 1.0
-        vmi = bus == "sourcebus" ? circuit["pu"] - circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"]) : vmin
-        vma = bus == "sourcebus" ? circuit["pu"] + circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"]) : vmax
+        ph1_ang = bus == sourcebus ? circuit["angle"] : 0.0
+        vm = bus == sourcebus ? circuit["pu"] : 1.0
+        vmi = bus == sourcebus ? circuit["pu"] - circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"]) : vmin
+        vma = bus == sourcebus ? circuit["pu"] + circuit["pu"] / (circuit["mvasc3"] / circuit["basemva"]) : vmax
 
         busDict["bus_i"] = n
         busDict["index"] = n
         busDict["name"] = bus
 
-        busDict["bus_type"] = bus == "sourcebus" ? 3 : 1
+        busDict["bus_type"] = bus == sourcebus ? 3 : 1
 
         busDict["vm"] = PMs.MultiConductorVector(parse_array(vm, nodes, nconductors))
         busDict["va"] = PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nconductors*(i-1))+ph1_ang for i in 1:nconductors], nodes, nconductors))
@@ -312,7 +313,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
     # sourcebus generator (created by circuit)
     circuit = dss_data["circuit"][1]
-    defaults = createVSource("sourcebus", "sourcebus"; to_sym_keys(circuit)...)
+    defaults = createVSource(get(circuit, "bus1", "sourcebus"), "sourcebus"; to_sym_keys(circuit)...)
 
     genDict = Dict{String,Any}()
 
@@ -348,6 +349,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
     PMs.import_remaining!(genDict, defaults, import_all; exclude=used)
 
     push!(tppm_data["gen"], genDict)
+
 
     if haskey(dss_data, "generator")
         for gen in dss_data["generator"]
@@ -957,7 +959,7 @@ was adjusted to accomodate that.
 function adjust_sourcegen_bounds!(tppm_data)
     emergamps = Array{Float64,1}([0.0])
     #sourcebus_n = find_bus("sourcebus", tppm_data)
-    sourcebus_n = [bus["index"] for (_,bus) in tppm_data["bus"] if haskey(bus, "name") && bus["name"]=="sourcebus"][1]
+    sourcebus_n = [bus["index"] for (_,bus) in tppm_data["bus"] if haskey(bus, "name") && bus["name"]==tppm_data["sourcebus"]][1]
     for (_,line) in tppm_data["branch"]
         if line["f_bus"] == sourcebus_n || line["t_bus"] == sourcebus_n
             append!(emergamps, line["rate_b"].values)
@@ -1515,7 +1517,7 @@ function parse_opendss(dss_data::Dict; import_all::Bool=false, vmin::Float64=0.9
 
     if haskey(dss_data, "circuit")
         circuit = dss_data["circuit"][1]
-        defaults = createVSource("", circuit["name"]; to_sym_keys(circuit)...)
+        defaults = createVSource(get(circuit, "bus1", "sourcebus"), circuit["name"]; to_sym_keys(circuit)...)
 
         tppm_data["name"] = defaults["name"]
         tppm_data["basekv"] = defaults["basekv"]
@@ -1523,6 +1525,7 @@ function parse_opendss(dss_data::Dict; import_all::Bool=false, vmin::Float64=0.9
         tppm_data["basefreq"] = pop!(tppm_data, "defaultbasefreq")
         tppm_data["pu"] = defaults["pu"]
         tppm_data["conductors"] = defaults["phases"]
+        tppm_data["sourcebus"] = defaults["bus1"]
     else
         Memento.error(LOGGER, "Circuit not defined, not a valid circuit!")
     end

--- a/test/data/opendss/test2_master.dss
+++ b/test/data/opendss/test2_master.dss
@@ -4,7 +4,7 @@ Clear
 new object=Circuit.TEST2
 
 ! Test circuit properties
-~ pu=1.1  r1=0.001  x1=0.01  r0=0.001  x0=0.01  basekv=69  angle=30
+~ pu=1.1  r1=0.001  x1=0.01  r0=0.001  x0=0.01  basekv=69  angle=30 bus1=testsource
 
 Redirect test2_Linecodes.dss
 Compile test2_Loadshape.dss
@@ -32,14 +32,14 @@ New "Capacitor.c2" bus1=b8 phases=3 kvar=[ 500] kv=25.0
 new capacitor.c3 bus1=b1 like=c2
 
 ! Reactors
-New Reactor.reactor1  bus1=SourceBus  bus2=b1  r=0  x=(1.05 0.75 0.001 5 * - - 125 15.0 / sqr *) normamps=400  emergamps=600
+New Reactor.reactor1  bus1=testsource  bus2=b1  r=0  x=(1.05 0.75 0.001 5 * - - 125 15.0 / sqr *) normamps=400  emergamps=600
 new reactor.reactor2 bus1=_b2 bus2=b10 like=reactor1
 new reactor.reactor3 bus1=b9 kvar=10.0
 new reactor.reactor4 bus1=b8 like=reactor3
 
 ! Transformers
-New "Transformer.t1" phases=1 windings=2 buses=[sourcebus,  _b2, ] conns=[wye, wye, ] kVs=[15.0, 15.0, ] kVAs=[50000, 50000, ] Xhl=1
-New "Transformer.t2" phases=3 windings=2 Xhl=0.02 buses=[sourcebus, b3-1, ] conns=[delta, wye, ] kVs=[69, 24.9, ] kVAs=[25000, 25000, ] taps=[1, 1, ] wdg=1 %R=0.0005 wdg=2 %R=0.0005
+New "Transformer.t1" phases=1 windings=2 buses=[testsource,  _b2, ] conns=[wye, wye, ] kVs=[15.0, 15.0, ] kVAs=[50000, 50000, ] Xhl=1
+New "Transformer.t2" phases=3 windings=2 Xhl=0.02 buses=[testsource, b3-1, ] conns=[delta, wye, ] kVs=[69, 24.9, ] kVAs=[25000, 25000, ] taps=[1, 1, ] wdg=1 %R=0.0005 wdg=2 %R=0.0005
 New Transformer.t3a phases=1  windings=2  buses=(b7.1,  b10.1)  conns=(wye, wye)  kvs=(10.0, 10)  kvas=(30000, 30000)  xhl=0.1 %loadloss=.002 wdg=2 Maxtap=1.05 Mintap=0.95 ppm=0
 New Transformer.t4  phases=3  windings=2  buses=(b8, b9.1.2.3.0)
 ~ conns=(delta wye)
@@ -52,7 +52,7 @@ new transformer.t5 buses=(b3-1, b5) like=t4
 
 ! Generators
 New Generator.g1 Bus1=b1  kV= 150 kW=1 Model=3 Vpu=1.05 Maxkvar=70000 Minkvar=10000 !  kvar=50000
-New Generator.g2 Bus1=sourcebus  kV= 120 kW=1 Phases=1 Model=3 Vpu=1.05 Maxkvar=70000 Minkvar=10000   !  kvar=60000
+New Generator.g2 Bus1=testsource  kV= 120 kW=1 Phases=1 Model=3 Vpu=1.05 Maxkvar=70000 Minkvar=10000   !  kvar=60000
 new generator.g3 bus1=b7 like=g2
 
 Set voltagebases=[115, 12.47, 0.48, 0.208]

--- a/test/opendss.jl
+++ b/test/opendss.jl
@@ -96,7 +96,7 @@
 
         @test tppm["name"] == "test2"
 
-        @test length(tppm) == 19 # 1 more entry for transformer dicts
+        @test length(tppm) == 20 # keep track of sourcebus
         @test length(dss) == 12
 
         # 26 buses and not 12, because of internal transformer buses;


### PR DESCRIPTION
OpenDSS allows for a sourcebus to not be called `sourcebus` by using the `bus1` kwarg on `circuit`.

Updates unit tests and changelog