### PR TITLE
PowerModels v0.12 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ ThreePhasePowerModels.jl Change Log
 - Allow for arbitrarily named sourcebus
 - Add json parser
 - Fix bug in OpenDSS parse of Capacitors [zbase factor and wrong sign] (#138)
-- Enforce function naming conventions (starts with `_`: internal function; ends with `!`: transforms data; `correct_`: corrects network data; `check_`: warnings about network data)
-- Update for PowerModels.jl v0.11
+- Enforce function naming conventions (starts with `_`: internal function; ends with `!`: transforms data; `correct_`: corrects network data; `check_`: warnings about network data) (breaking)
+- Update for PowerModels.jl v0.12 (breaking)
+- Enforce constraint/variable naming conventions to include `_tp` (breaking)
+- Add automatic export of non-internal functions (all functions not prefixed with `_`)
 
 ### v0.3.0
 - Update to JuMP v0.19/MathOptInterface

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -77,9 +77,9 @@ version = "0.10.3"
 
 [[InfrastructureModels]]
 deps = ["JuMP", "Memento"]
-git-tree-sha1 = "ec3f1ba27dbfd29a93f3c520ee189ce32deec049"
+git-tree-sha1 = "131d2d24a2a0d404f59dceab2fb8f8cca2aadce5"
 uuid = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
-version = "0.2.0"
+version = "0.2.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -93,9 +93,9 @@ version = "0.20.0"
 
 [[JuMP]]
 deps = ["Calculus", "DataStructures", "ForwardDiff", "LinearAlgebra", "MathOptInterface", "NaNMath", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "5df42febdee8ac7db9de66c712e439a6ff06459d"
+git-tree-sha1 = "a37fdb14ee3a04b4df44c20a73da89c57035bdf2"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.19.1"
+version = "0.19.2"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -153,9 +153,11 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PowerModels]]
 deps = ["InfrastructureModels", "JSON", "JuMP", "LinearAlgebra", "MathOptInterface", "Memento", "SparseArrays"]
-git-tree-sha1 = "c9d4280b0cd1cd6dc10bca03d8c17950a1f90e8a"
+git-tree-sha1 = "d766058e401a32e43e916b881ca2b5a19e208656"
+repo-rev = "setpoint-fix"
+repo-url = "https://github.com/lanl-ansi/PowerModels.jl.git"
 uuid = "c36e90e8-916a-50a6-bd94-075b64ef4655"
-version = "0.11.1"
+version = "0.12.0"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -193,10 +195,10 @@ uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
 version = "0.7.2"
 
 [[StaticArrays]]
-deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "3841b39ed5f047db1162627bf5f80a9cd3e39ae2"
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "db23bbf50064c582b6f2b9b043c8e7e98ea8c0c6"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.10.3"
+version = "0.11.0"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -153,8 +153,8 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PowerModels]]
 deps = ["InfrastructureModels", "JSON", "JuMP", "LinearAlgebra", "MathOptInterface", "Memento", "SparseArrays"]
-git-tree-sha1 = "d766058e401a32e43e916b881ca2b5a19e208656"
-repo-rev = "setpoint-fix"
+git-tree-sha1 = "9538663d7a58472d0a642a3efa97cc97481353f2"
+repo-rev = "master"
 repo-url = "https://github.com/lanl-ansi/PowerModels.jl.git"
 uuid = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 version = "0.12.0"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ JSON = ">= 0.18"
 JuMP = "^0.19.1"
 Juniper = ">= 0.4"
 Memento = ">= 0.8, < 0.13"
-PowerModels = "^0.11"
+PowerModels = "^0.12"
 SCS = ">= 0.4"
 julia = "^1"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 
 [compat]
 InfrastructureModels = "~0.2"
-PowerModels = "~0.11"
+PowerModels = "~0.12"

--- a/src/ThreePhasePowerModels.jl
+++ b/src/ThreePhasePowerModels.jl
@@ -10,7 +10,7 @@ import LinearAlgebra
 const PMs = PowerModels
 
 function __init__()
-    global LOGGER = Memento.getlogger(PowerModels)
+    global _LOGGER = Memento.getlogger(PowerModels)
 end
 
 include("core/ref.jl")

--- a/src/ThreePhasePowerModels.jl
+++ b/src/ThreePhasePowerModels.jl
@@ -7,7 +7,7 @@ import Memento
 
 import LinearAlgebra
 
-const PMs = PowerModels
+const _PMs = PowerModels
 
 function __init__()
     global _LOGGER = Memento.getlogger(PowerModels)

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -1,7 +1,7 @@
 
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel, i::Int; kwargs...)
+function constraint_tp_branch_current(pm::PMs.GenericPowerModel; kwargs...)
     for c in PMs.conductor_ids(pm)
-        PMs.constraint_branch_current(pm, i, cnd=c; kwargs...)
+        PMs.constraint_model_current(pm; cnd=c, kwargs...)
     end
 end
 

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -1,25 +1,25 @@
 
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel; kwargs...)
-    for c in PMs.conductor_ids(pm)
-        PMs.constraint_model_current(pm; cnd=c, kwargs...)
+function constraint_tp_model_current(pm::_PMs.GenericPowerModel; kwargs...)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.constraint_model_current(pm; cnd=c, kwargs...)
     end
 end
 
 
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
-    for cnd in PMs.conductor_ids(pm)
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
+    for cnd in _PMs.conductor_ids(pm)
         constraint_tp_theta_ref(pm, nw, cnd, i)
     end
 end
 
 
-function constraint_tp_storage_loss(pm::PMs.GenericPowerModel, n::Int, i, bus, r, x, standby_loss)
-    conductors = PMs.conductor_ids(pm)
-    vm = [PMs.var(pm, n, c, :vm, bus) for c in conductors]
-    ps = [PMs.var(pm, n, c, :ps, i) for c in conductors]
-    qs = [PMs.var(pm, n, c, :qs, i) for c in conductors]
-    sc = PMs.var(pm, n, :sc, i)
-    sd = PMs.var(pm, n, :sd, i)
+function constraint_tp_storage_loss(pm::_PMs.GenericPowerModel, n::Int, i, bus, r, x, standby_loss)
+    conductors = _PMs.conductor_ids(pm)
+    vm = [_PMs.var(pm, n, c, :vm, bus) for c in conductors]
+    ps = [_PMs.var(pm, n, c, :ps, i) for c in conductors]
+    qs = [_PMs.var(pm, n, c, :qs, i) for c in conductors]
+    sc = _PMs.var(pm, n, :sc, i)
+    sd = _PMs.var(pm, n, :sd, i)
 
     JuMP.@NLconstraint(pm.model, sum(ps[c] for c in conductors) + (sd - sc) == standby_loss + sum( r[c]*(ps[c]^2 + qs[c]^2)/vm[c]^2 for c in conductors))
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -207,7 +207,7 @@ end
 
 function constraint_tp_trans(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
     if PMs.ref(pm, pm.cnw, :conductors)!=3
-        Memento.error(LOGGER, "Transformers only work with networks with three conductors.")
+        Memento.error(_LOGGER, "Transformers only work with networks with three conductors.")
     end
     (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = calc_tp_trans_Tvi(pm, i)
     f_bus = PMs.ref(pm, :trans, i)["f_bus"]
@@ -222,7 +222,7 @@ end
 
 function constraint_tp_oltc(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
     if PMs.ref(pm, pm.cnw, :conductors)!=3
-        Memento.error(LOGGER, "Transformers only work with networks with three conductors.")
+        Memento.error(_LOGGER, "Transformers only work with networks with three conductors.")
     end
     (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = calc_tp_trans_Tvi(pm, i)
     trans = PMs.ref(pm, :trans, i)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -1,120 +1,120 @@
 # Three-phase specific constraints
 
 ""
-function constraint_kcl_shunt_slack(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    if !haskey(PMs.con(pm, nw, cnd), :kcl_p)
-        PMs.con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
+function constraint_tp_power_balance_shunt_slack(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    if !haskey(_PMs.con(pm, nw, cnd), :kcl_p)
+        _PMs.con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
     end
-    if !haskey(PMs.con(pm, nw, cnd), :kcl_q)
-        PMs.con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
+    if !haskey(_PMs.con(pm, nw, cnd), :kcl_q)
+        _PMs.con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
     end
 
-    bus = PMs.ref(pm, nw, :bus, i)
-    bus_arcs = PMs.ref(pm, nw, :bus_arcs, i)
-    bus_arcs_dc = PMs.ref(pm, nw, :bus_arcs_dc, i)
-    bus_gens = PMs.ref(pm, nw, :bus_gens, i)
-    bus_loads = PMs.ref(pm, nw, :bus_loads, i)
-    bus_shunts = PMs.ref(pm, nw, :bus_shunts, i)
+    bus = _PMs.ref(pm, nw, :bus, i)
+    bus_arcs = _PMs.ref(pm, nw, :bus_arcs, i)
+    bus_arcs_dc = _PMs.ref(pm, nw, :bus_arcs_dc, i)
+    bus_gens = _PMs.ref(pm, nw, :bus_gens, i)
+    bus_loads = _PMs.ref(pm, nw, :bus_loads, i)
+    bus_shunts = _PMs.ref(pm, nw, :bus_shunts, i)
 
-    bus_pd = Dict(k => PMs.ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
-    bus_qd = Dict(k => PMs.ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
+    bus_pd = Dict(k => _PMs.ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
+    bus_qd = Dict(k => _PMs.ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
 
-    bus_gs = Dict(k => PMs.ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
-    bus_bs = Dict(k => PMs.ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
+    bus_gs = Dict(k => _PMs.ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
+    bus_bs = Dict(k => _PMs.ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
 
-    constraint_kcl_shunt_slack(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+    constraint_tp_power_balance_shunt_slack(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
 
 ""
-function constraint_tp_voltage(pm::PMs.GenericPowerModel; nw::Int=pm.cnw)
-    for c in PMs.conductor_ids(pm)
-        constraint_tp_voltage(pm, nw, c)
+function constraint_tp_model_voltage(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw)
+    for c in _PMs.conductor_ids(pm)
+        constraint_tp_model_voltage(pm, nw, c)
     end
 end
 
 
 ""
-function constraint_ohms_tp_yt_from(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_ohms_yt_from(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
 
-    g, b = PMs.calc_branch_y(branch)
-    tr, ti = PMs.calc_branch_t(branch)
+    g, b = _PMs.calc_branch_y(branch)
+    tr, ti = _PMs.calc_branch_t(branch)
     g_fr = branch["g_fr"]
     b_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    constraint_ohms_tp_yt_from(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
+    constraint_tp_ohms_yt_from(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
 end
 
 
 ""
-function constraint_ohms_tp_yt_to(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_ohms_yt_to(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
 
-    g, b = PMs.calc_branch_y(branch)
-    tr, ti = PMs.calc_branch_t(branch)
+    g, b = _PMs.calc_branch_y(branch)
+    tr, ti = _PMs.calc_branch_t(branch)
     g_to = branch["g_to"]
     b_to = branch["b_to"]
     tm = branch["tap"]
 
-    constraint_ohms_tp_yt_to(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
+    constraint_tp_ohms_yt_to(pm, nw, cnd, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
 end
 
 
 ""
-function constraint_ohms_tp_yt_from_on_off(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_ohms_yt_from_on_off(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
 
-    g, b = PMs.calc_branch_y(branch)
-    tr, ti = PMs.calc_branch_t(branch)
+    g, b = _PMs.calc_branch_y(branch)
+    tr, ti = _PMs.calc_branch_t(branch)
     g_fr = branch["g_fr"]
     b_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    vad_min = [PMs.ref(pm, nw, :off_angmin, c) for c in PMs.conductor_ids(pm)]
-    vad_max = [PMs.ref(pm, nw, :off_angmax, c) for c in PMs.conductor_ids(pm)]
+    vad_min = [_PMs.ref(pm, nw, :off_angmin, c) for c in _PMs.conductor_ids(pm)]
+    vad_max = [_PMs.ref(pm, nw, :off_angmax, c) for c in _PMs.conductor_ids(pm)]
 
-    constraint_ohms_tp_yt_from_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
+    constraint_tp_ohms_yt_from_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
 end
 
 
 ""
-function constraint_ohms_tp_yt_to_on_off(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_ohms_yt_to_on_off(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
 
-    g, b = PMs.calc_branch_y(branch)
-    tr, ti = PMs.calc_branch_t(branch)
+    g, b = _PMs.calc_branch_y(branch)
+    tr, ti = _PMs.calc_branch_t(branch)
     g_to = branch["g_to"]
     b_to = branch["b_to"]
     tm = branch["tap"]
 
-    vad_min = [PMs.ref(pm, nw, :off_angmin, c) for c in PMs.conductor_ids(pm)]
-    vad_max = [PMs.ref(pm, nw, :off_angmax, c) for c in PMs.conductor_ids(pm)]
+    vad_min = [_PMs.ref(pm, nw, :off_angmin, c) for c in _PMs.conductor_ids(pm)]
+    vad_max = [_PMs.ref(pm, nw, :off_angmax, c) for c in _PMs.conductor_ids(pm)]
 
-    constraint_ohms_tp_yt_to_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
+    constraint_tp_ohms_yt_to_on_off(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
 end
 
 
 ""
-function constraint_voltage_magnitude_difference(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_voltage_magnitude_difference(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
@@ -126,11 +126,11 @@ function constraint_voltage_magnitude_difference(pm::PMs.GenericPowerModel, i::I
     b_sh_fr = branch["b_fr"]
     tm = branch["tap"]
 
-    constraint_voltage_magnitude_difference(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
+    constraint_tp_voltage_magnitude_difference(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
 end
 
-function constraint_tp_voltage_magnitude_difference(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_model_voltage_magnitude_difference(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
@@ -142,12 +142,12 @@ function constraint_tp_voltage_magnitude_difference(pm::PMs.GenericPowerModel, i
     b_sh_fr = diagm(0 => branch["b_fr"].values)
     tm = branch["tap"].values
 
-    constraint_tp_voltage_magnitude_difference(pm, nw, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
+    constraint_tp_model_voltage_magnitude_difference(pm, nw, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
 end
 
 
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}; nw::Int=pm.cnw) where T <: AbstractUBFForm
-    for (i,branch) in PMs.ref(pm, nw, :branch)
+function constraint_tp_model_current(pm::_PMs.GenericPowerModel{T}; nw::Int=pm.cnw) where T <: AbstractUBFForm
+    for (i,branch) in _PMs.ref(pm, nw, :branch)
         f_bus = branch["f_bus"]
         t_bus = branch["t_bus"]
         f_idx = (i, f_bus, t_bus)
@@ -155,13 +155,13 @@ function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}; nw::Int=pm.c
         g_sh_fr = diagm(0 => branch["g_fr"].values)
         b_sh_fr = diagm(0 => branch["b_fr"].values)
 
-        constraint_tp_branch_current(pm, nw, i, f_bus, f_idx, g_sh_fr, b_sh_fr)
+        constraint_tp_model_current(pm, nw, i, f_bus, f_idx, g_sh_fr, b_sh_fr)
     end
 end
 
 
-function constraint_flow_losses(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
@@ -175,11 +175,11 @@ function constraint_flow_losses(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cn
     b_sh_fr = branch["b_fr"][cnd]
     b_sh_to = branch["b_to"][cnd]
 
-    constraint_flow_losses(pm::PMs.GenericPowerModel, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
+    constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
 end
 
-function constraint_tp_flow_losses(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
-    branch = PMs.ref(pm, nw, :branch, i)
+function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
+    branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
@@ -192,27 +192,27 @@ function constraint_tp_flow_losses(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm
     b_sh_fr = diagm(0 => branch["b_fr"]).values
     b_sh_to = diagm(0 => branch["b_to"]).values
 
-    constraint_tp_flow_losses(pm::PMs.GenericPowerModel, nw, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to)
+    constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, nw, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to)
 end
 
 
 ""
-function constraint_tp_storage_exchange(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
-    storage = PMs.ref(pm, nw, :storage, i)
+function constraint_tp_storage_exchange(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
+    storage = _PMs.ref(pm, nw, :storage, i)
 
-    PMs.constraint_storage_complementarity(pm, nw, i)
+    _PMs.constraint_storage_complementarity(pm, nw, i)
     constraint_tp_storage_loss(pm, nw, i, storage["storage_bus"], storage["r"], storage["x"], storage["standby_loss"])
 end
 
 
-function constraint_tp_trans(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
-    if PMs.ref(pm, pm.cnw, :conductors)!=3
+function constraint_tp_trans(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
+    if _PMs.ref(pm, pm.cnw, :conductors)!=3
         Memento.error(_LOGGER, "Transformers only work with networks with three conductors.")
     end
-    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = calc_tp_trans_Tvi(pm, i)
-    f_bus = PMs.ref(pm, :trans, i)["f_bus"]
-    t_bus = PMs.ref(pm, :trans, i)["t_bus"]
-    tm = PMs.ref(pm, :trans, i)["tm"]
+    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = _calc_tp_trans_Tvi(pm, i)
+    f_bus = _PMs.ref(pm, :trans, i)["f_bus"]
+    t_bus = _PMs.ref(pm, :trans, i)["t_bus"]
+    tm = _PMs.ref(pm, :trans, i)["tm"]
     constraint_tp_trans_voltage(pm, nw, i, f_bus, t_bus, tm, Tv_fr, Tv_im, Cv_to)
     f_idx = (i, f_bus, t_bus)
     t_idx = (i, t_bus, f_bus)
@@ -220,12 +220,12 @@ function constraint_tp_trans(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
 end
 
 
-function constraint_tp_oltc(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
-    if PMs.ref(pm, pm.cnw, :conductors)!=3
+function constraint_tp_oltc(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
+    if _PMs.ref(pm, pm.cnw, :conductors)!=3
         Memento.error(_LOGGER, "Transformers only work with networks with three conductors.")
     end
-    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = calc_tp_trans_Tvi(pm, i)
-    trans = PMs.ref(pm, :trans, i)
+    (Tv_fr,Tv_im,Ti_fr,Ti_im,Cv_to) = _calc_tp_trans_Tvi(pm, i)
+    trans = _PMs.ref(pm, :trans, i)
     f_bus = trans["f_bus"]
     t_bus = trans["t_bus"]
     constraint_tp_oltc_voltage(pm, nw, i, f_bus, t_bus, Tv_fr, Tv_im, Cv_to)
@@ -233,7 +233,7 @@ function constraint_tp_oltc(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
     t_idx = (i, t_bus, f_bus)
     constraint_tp_oltc_flow(pm, nw, i, f_bus, t_bus, f_idx, t_idx, Ti_fr, Ti_im, Cv_to)
     # fix the taps with a constraint which are not free
-    trans = PMs.ref(pm, :trans, i)
+    trans = _PMs.ref(pm, :trans, i)
     fixed = trans["fixed"]
     tm = trans["tm"]
     constraint_tp_oltc_tap_fix(pm, i, fixed, tm)
@@ -241,27 +241,27 @@ end
 
 
 "KCL including transformer arcs."
-function constraint_kcl_shunt_trans(pm::PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    if !haskey(PMs.con(pm, nw, cnd), :kcl_p)
-        PMs.con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
+function constraint_tp_power_balance_shunt_trans(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    if !haskey(_PMs.con(pm, nw, cnd), :kcl_p)
+        _PMs.con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
     end
-    if !haskey(PMs.con(pm, nw, cnd), :kcl_q)
-        PMs.con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
+    if !haskey(_PMs.con(pm, nw, cnd), :kcl_q)
+        _PMs.con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
     end
 
-    bus = PMs.ref(pm, nw, :bus, i)
-    bus_arcs = PMs.ref(pm, nw, :bus_arcs, i)
-    bus_arcs_dc = PMs.ref(pm, nw, :bus_arcs_dc, i)
-    bus_gens = PMs.ref(pm, nw, :bus_gens, i)
-    bus_loads = PMs.ref(pm, nw, :bus_loads, i)
-    bus_shunts = PMs.ref(pm, nw, :bus_shunts, i)
-    bus_arcs_trans = PMs.ref(pm, nw, :bus_arcs_trans, i)
+    bus = _PMs.ref(pm, nw, :bus, i)
+    bus_arcs = _PMs.ref(pm, nw, :bus_arcs, i)
+    bus_arcs_dc = _PMs.ref(pm, nw, :bus_arcs_dc, i)
+    bus_gens = _PMs.ref(pm, nw, :bus_gens, i)
+    bus_loads = _PMs.ref(pm, nw, :bus_loads, i)
+    bus_shunts = _PMs.ref(pm, nw, :bus_shunts, i)
+    bus_arcs_trans = _PMs.ref(pm, nw, :bus_arcs_trans, i)
 
-    bus_pd = Dict(k => PMs.ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
-    bus_qd = Dict(k => PMs.ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
+    bus_pd = Dict(k => _PMs.ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
+    bus_qd = Dict(k => _PMs.ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
 
-    bus_gs = Dict(k => PMs.ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
-    bus_bs = Dict(k => PMs.ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
+    bus_gs = Dict(k => _PMs.ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
+    bus_bs = Dict(k => _PMs.ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
 
-    constraint_kcl_shunt_trans(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+    constraint_tp_power_balance_shunt_trans(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -146,16 +146,17 @@ function constraint_tp_voltage_magnitude_difference(pm::PMs.GenericPowerModel, i
 end
 
 
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}, i::Int; nw::Int=pm.cnw) where T <: AbstractUBFForm
-    branch = PMs.ref(pm, nw, :branch, i)
-    f_bus = branch["f_bus"]
-    t_bus = branch["t_bus"]
-    f_idx = (i, f_bus, t_bus)
+function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}; nw::Int=pm.cnw) where T <: AbstractUBFForm
+    for (i,branch) in PMs.ref(pm, nw, :branch)
+        f_bus = branch["f_bus"]
+        t_bus = branch["t_bus"]
+        f_idx = (i, f_bus, t_bus)
 
-    g_sh_fr = diagm(0 => branch["g_fr"].values)
-    b_sh_fr = diagm(0 => branch["b_fr"].values)
+        g_sh_fr = diagm(0 => branch["g_fr"].values)
+        b_sh_fr = diagm(0 => branch["b_fr"].values)
 
-    constraint_tp_branch_current(pm, nw, i, f_bus, f_idx, g_sh_fr, b_sh_fr)
+        constraint_tp_branch_current(pm, nw, i, f_bus, f_idx, g_sh_fr, b_sh_fr)
+    end
 end
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -159,7 +159,7 @@ function constraint_tp_model_current(pm::_PMs.GenericPowerModel{T}; nw::Int=pm.c
     end
 end
 
-
+#= ??? DEPRECIATED ???
 function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     branch = _PMs.ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -177,6 +177,7 @@ function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, i::Int; nw::Int=p
 
     constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
 end
+=#
 
 function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel, i::Int; nw::Int=pm.cnw)
     branch = _PMs.ref(pm, nw, :branch, i)

--- a/src/core/export.jl
+++ b/src/core/export.jl
@@ -6,8 +6,6 @@
 # Do not add ThreePhasePowerModels-defined symbols to this exclude list. Instead, rename
 # them with an underscore.
 
-# Not yet used
-#=
 const _EXCLUDE_SYMBOLS = [Symbol(@__MODULE__), :eval, :include]
 for sym in names(@__MODULE__, all=true)
     sym_string = string(sym)
@@ -20,7 +18,6 @@ for sym in names(@__MODULE__, all=true)
     end
     @eval export $sym
 end
-=#
 
 # the follow items are also exported for user-friendlyness when calling
 # `using ThreePhasePowerModels`

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -1,10 +1,10 @@
 "a quadratic penalty for bus power slack variables"
-function objective_min_bus_power_slack(pm::PMs.GenericPowerModel)
+function objective_min_bus_power_slack(pm::_PMs.GenericPowerModel)
     return JuMP.@objective(pm.model, Min,
         sum(
             sum(
-                sum( PMs.var(pm, n, c, :p_slack, i)^2 + PMs.var(pm, n, c, :q_slack, i)^2 for (i,bus) in nw_ref[:bus])
-            for c in PMs.conductor_ids(pm, n))
-        for (n, nw_ref) in PMs.nws(pm))
+                sum( _PMs.var(pm, n, c, :p_slack, i)^2 + _PMs.var(pm, n, c, :q_slack, i)^2 for (i,bus) in nw_ref[:bus])
+            for c in _PMs.conductor_ids(pm, n))
+        for (n, nw_ref) in _PMs.nws(pm))
     )
 end

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -63,31 +63,31 @@ function calc_tp_trans_Tvi(pm::PMs.GenericPowerModel, i::Int; nw=pm.cnw)
     # grounding disregarded
     for config in [trans["config_to"], trans["config_fr"]]
         if haskey(config, "grounded") && config["grounded"]==false
-            Memento.warning(LOGGER, "The wye winding is considered to be grounded instead of ungrounded.")
+            Memento.warning(_LOGGER, "The wye winding is considered to be grounded instead of ungrounded.")
         end
     end
     # make sure the secondary is y+123
     if trans["config_to"]["type"]!="wye"
-        Memento.error(LOGGER, "Secondary should always be of wye type.")
+        Memento.error(_LOGGER, "Secondary should always be of wye type.")
     end
     if trans["config_to"]["cnd"]!=[1,2,3]
-        Memento.error(LOGGER, "Secondary should always be connected in 123.")
+        Memento.error(_LOGGER, "Secondary should always be connected in 123.")
     end
     if trans["config_to"]["polarity"]!='+'
-        Memento.error(LOGGER, "Secondary should always be of positive polarity.")
+        Memento.error(_LOGGER, "Secondary should always be of positive polarity.")
     end
     # connection transformers
     perm = trans["config_fr"]["cnd"]
     if !(perm in [[1,2,3], [3,1,2], [2,3,1]])
-        Memento.error(LOGGER, "Only the permutations \"123\", \"312\" and \"231\" are supported, but got \"$perm\".")
+        Memento.error(_LOGGER, "Only the permutations \"123\", \"312\" and \"231\" are supported, but got \"$perm\".")
     end
     polarity = trans["config_fr"]["polarity"]
     if !(polarity in ['+', '-'])
-        Memento.error(LOGGER, "The polarity should be either \'+\' or \'-\', but got \'$polarity\'.")
+        Memento.error(_LOGGER, "The polarity should be either \'+\' or \'-\', but got \'$polarity\'.")
     end
     dyz = trans["config_fr"]["type"]
     if !(dyz in ["delta", "wye"])
-        Memento.error(LOGGER, "The winding type should be either delta or wye, but got \'$dyz\'.")
+        Memento.error(_LOGGER, "The winding type should be either delta or wye, but got \'$dyz\'.")
     end
     # for now, grounded by default
     #grounded = length(trans["conn"])>5 && trans["conn"][6]=='n'

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -1,23 +1,23 @@
 ""
-function variable_tp_voltage(pm::PMs.GenericPowerModel; kwargs...)
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_voltage(pm, cnd=c; kwargs...)
+function variable_tp_voltage(pm::_PMs.GenericPowerModel; kwargs...)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_voltage(pm, cnd=c; kwargs...)
     end
 end
 
 
 ""
-function variable_tp_branch_flow(pm::PMs.GenericPowerModel; kwargs...)
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_branch_flow(pm, cnd=c; kwargs...)
+function variable_tp_branch_flow(pm::_PMs.GenericPowerModel; kwargs...)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_branch_flow(pm, cnd=c; kwargs...)
     end
 end
 
 
 
 ""
-function variable_tp_voltage(pm::PMs.GenericPowerModel{T}; kwargs...) where T <: PMs.AbstractWRForm
-    for c in PMs.conductor_ids(pm)
+function variable_tp_voltage(pm::_PMs.GenericPowerModel{T}; kwargs...) where T <: _PMs.AbstractWRForm
+    for c in _PMs.conductor_ids(pm)
         variable_tp_voltage_magnitude_sqr(pm, cnd=c; kwargs...)
         variable_tp_voltage_product(pm, cnd=c; kwargs...)
     end
@@ -25,51 +25,51 @@ end
 
 
 "variable: `w[i] >= 0` for `i` in `bus`es"
-function variable_tp_voltage_magnitude_sqr(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
-    bus_cnd = [(i, c) for i in PMs.ids(pm, nw, :bus) for c in PMs.conductor_ids(pm)]
+function variable_tp_voltage_magnitude_sqr(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+    bus_cnd = [(i, c) for i in _PMs.ids(pm, nw, :bus) for c in _PMs.conductor_ids(pm)]
 
     if bounded
-        W = PMs.var(pm, nw)[:w] = JuMP.@variable(pm.model,
+        W = _PMs.var(pm, nw)[:w] = JuMP.@variable(pm.model,
             [i in bus_cnd], base_name="$(nw)_w",
-            lower_bound = PMs.ref(pm, nw, :bus, i[1], "vmin", i[2])^2,
-            upper_bound = PMs.ref(pm, nw, :bus, i[1], "vmax", i[2])^2,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
+            lower_bound = _PMs.ref(pm, nw, :bus, i[1], "vmin", i[2])^2,
+            upper_bound = _PMs.ref(pm, nw, :bus, i[1], "vmax", i[2])^2,
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
         )
     else
-        W = PMs.var(pm, nw)[:w] = JuMP.@variable(pm.model,
+        W = _PMs.var(pm, nw)[:w] = JuMP.@variable(pm.model,
             [i in bus_cnd], base_name="$(nw)_w",
             lower_bound = 0,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
         )
     end
 
-    PMs.var(pm, nw, cnd)[:w] = Dict{Int,Any}()
-    for i in PMs.ids(pm, nw, :bus)
-        PMs.var(pm, nw, cnd, :w)[i] = W[(i, cnd)]
+    _PMs.var(pm, nw, cnd)[:w] = Dict{Int,Any}()
+    for i in _PMs.ids(pm, nw, :bus)
+        _PMs.var(pm, nw, cnd, :w)[i] = W[(i, cnd)]
     end
 end
 
 
 ""
-function variable_tp_voltage_product(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
-    bp_cndf_cndt = [(i, j, c, d) for (i,j) in keys(PMs.ref(pm, nw, :buspairs)) for c in PMs.conductor_ids(pm) for d in PMs.conductor_ids(pm)]
-    bus_cnd = [(i, i, c, d) for i in PMs.ids(pm, nw, :bus) for c in PMs.conductor_ids(pm) for d in PMs.conductor_ids(pm) if c != d]
+function variable_tp_voltage_product(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+    bp_cndf_cndt = [(i, j, c, d) for (i,j) in keys(_PMs.ref(pm, nw, :buspairs)) for c in _PMs.conductor_ids(pm) for d in _PMs.conductor_ids(pm)]
+    bus_cnd = [(i, i, c, d) for i in _PMs.ids(pm, nw, :bus) for c in _PMs.conductor_ids(pm) for d in _PMs.conductor_ids(pm) if c != d]
     append!(bus_cnd, bp_cndf_cndt)
 
-    WR = PMs.var(pm, nw)[:wr] = JuMP.@variable(pm.model,
+    WR = _PMs.var(pm, nw)[:wr] = JuMP.@variable(pm.model,
         [b in bus_cnd], base_name="$(nw)_wr",
-        start = PMs. comp_start_value(b[1] != b[2] ? PMs.ref(pm, nw, :buspairs, b[1:2]) : PMs.ref(pm, nw, :bus, b[1]), "wr_start", b[3], 1.0)
+        start = _PMs.comp_start_value(b[1] != b[2] ? _PMs.ref(pm, nw, :buspairs, b[1:2]) : _PMs.ref(pm, nw, :bus, b[1]), "wr_start", b[3], 1.0)
     )
 
-    WI = PMs.var(pm, nw)[:wi] = JuMP.@variable(pm.model,
+    WI = _PMs.var(pm, nw)[:wi] = JuMP.@variable(pm.model,
         [b in bus_cnd], base_name="$(nw)_wi",
-        start = PMs. comp_start_value(b[1] != b[2] ? PMs.ref(pm, nw, :buspairs, b[1:2]) : PMs.ref(pm, nw, :bus, b[1]), "wi_start", b[3])
+        start = _PMs.comp_start_value(b[1] != b[2] ? _PMs.ref(pm, nw, :buspairs, b[1:2]) : _PMs.ref(pm, nw, :bus, b[1]), "wi_start", b[3])
     )
 
     if bounded
         # Diagonal bounds
-        wr_min, wr_max, wi_min, wi_max = PMs.ref_calc_voltage_product_bounds(PMs.ref(pm, nw, :buspairs), cnd)
-        for (i, j) in PMs.ids(pm, nw, :buspairs)
+        wr_min, wr_max, wi_min, wi_max = _PMs.ref_calc_voltage_product_bounds(_PMs.ref(pm, nw, :buspairs), cnd)
+        for (i, j) in _PMs.ids(pm, nw, :buspairs)
             JuMP.set_upper_bound(WR[(i, j, cnd, cnd)], wr_max[(i,j)])
             JuMP.set_upper_bound(WI[(i, j, cnd, cnd)], wi_max[(i,j)])
 
@@ -78,7 +78,7 @@ function variable_tp_voltage_product(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, 
         end
 
         # Off-diagonal bounds
-        for c in PMs.conductor_ids(pm)
+        for c in _PMs.conductor_ids(pm)
             if c != cnd
                 wr_min, wr_max, wi_min, wi_max = calc_tp_voltage_product_bounds(pm, bus_cnd)
                 for k in bus_cnd
@@ -92,73 +92,73 @@ function variable_tp_voltage_product(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, 
         end
     end
 
-    PMs.var(pm, nw, cnd)[:wr] = Dict{Tuple{Int,Int},Any}()
-    PMs.var(pm, nw, cnd)[:wi] = Dict{Tuple{Int,Int},Any}()
-    for (i, j) in PMs.ids(pm, nw, :buspairs)
-        PMs.var(pm, nw, cnd, :wr)[(i,j)] = WR[(i, j, cnd, cnd)]
-        PMs.var(pm, nw, cnd, :wi)[(i,j)] = WI[(i, j, cnd, cnd)]
+    _PMs.var(pm, nw, cnd)[:wr] = Dict{Tuple{Int,Int},Any}()
+    _PMs.var(pm, nw, cnd)[:wi] = Dict{Tuple{Int,Int},Any}()
+    for (i, j) in _PMs.ids(pm, nw, :buspairs)
+        _PMs.var(pm, nw, cnd, :wr)[(i,j)] = WR[(i, j, cnd, cnd)]
+        _PMs.var(pm, nw, cnd, :wi)[(i,j)] = WI[(i, j, cnd, cnd)]
     end
 end
 
 
 "variables for modeling storage units, includes grid injection and internal variables"
-function variable_tp_storage(pm::PMs.GenericPowerModel; kwargs...)
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_active_storage(pm, cnd=c; kwargs...)
-        PMs.variable_reactive_storage(pm, cnd=c; kwargs...)
+function variable_tp_storage(pm::_PMs.GenericPowerModel; kwargs...)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_active_storage(pm, cnd=c; kwargs...)
+        _PMs.variable_reactive_storage(pm, cnd=c; kwargs...)
     end
-    PMs.variable_storage_energy(pm; kwargs...)
-    PMs.variable_storage_charge(pm; kwargs...)
-    PMs.variable_storage_discharge(pm; kwargs...)
+    _PMs.variable_storage_energy(pm; kwargs...)
+    _PMs.variable_storage_charge(pm; kwargs...)
+    _PMs.variable_storage_discharge(pm; kwargs...)
 end
 
 
 "generates variables for both `active` and `reactive` slack at each bus"
-function variable_bus_power_slack(pm::PMs.GenericPowerModel; kwargs...)
-    variable_active_bus_power_slack(pm; kwargs...)
-    variable_reactive_bus_power_slack(pm; kwargs...)
+function variable_tp_bus_power_slack(pm::_PMs.GenericPowerModel; kwargs...)
+    variable_tp_active_bus_power_slack(pm; kwargs...)
+    variable_tp_reactive_bus_power_slack(pm; kwargs...)
 end
 
 
 ""
-function variable_active_bus_power_slack(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    PMs.var(pm, nw, cnd)[:p_slack] = JuMP.@variable(pm.model,
-        [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_p_slack",
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "p_slack_start", cnd)
+function variable_tp_active_bus_power_slack(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    _PMs.var(pm, nw, cnd)[:p_slack] = JuMP.@variable(pm.model,
+        [i in _PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_p_slack",
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i), "p_slack_start", cnd)
     )
 end
 
 
 ""
-function variable_reactive_bus_power_slack(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    PMs.var(pm, nw, cnd)[:q_slack] = JuMP.@variable(pm.model,
-        [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_q_slack",
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "q_slack_start", cnd)
+function variable_tp_reactive_bus_power_slack(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    _PMs.var(pm, nw, cnd)[:q_slack] = JuMP.@variable(pm.model,
+        [i in _PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_q_slack",
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i), "q_slack_start", cnd)
     )
 end
 
 "Creates variables for both `active` and `reactive` power flow at each transformer."
-function variable_tp_trans_flow(pm::PMs.GenericPowerModel; kwargs...)
+function variable_tp_trans_flow(pm::_PMs.GenericPowerModel; kwargs...)
     variable_tp_trans_active_flow(pm; kwargs...)
     variable_tp_trans_reactive_flow(pm; kwargs...)
 end
 
 
 "Create variables for the active power flowing into all transformer windings."
-function variable_tp_trans_active_flow(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, bounded=true)
-    for cnd in PMs.conductor_ids(pm)
-        PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
-            [(l,i,j) in PMs.ref(pm, nw, :arcs_trans)],
+function variable_tp_trans_active_flow(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, bounded=true)
+    for cnd in _PMs.conductor_ids(pm)
+        _PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
+            [(l,i,j) in _PMs.ref(pm, nw, :arcs_trans)],
             base_name="$(nw)_$(cnd)_p_trans",
             start=0
         )
         if bounded
-            for arc in PMs.ref(pm, nw, :arcs_trans)
+            for arc in _PMs.ref(pm, nw, :arcs_trans)
                 tr_id = arc[1]
-                flow_lb  = -PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                flow_ub  =  PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                JuMP.set_lower_bound(PMs.var(pm, nw, cnd, :pt, arc), flow_lb)
-                JuMP.set_upper_bound(PMs.var(pm, nw, cnd, :pt, arc), flow_ub)
+                flow_lb  = -_PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_ub  =  _PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                JuMP.set_lower_bound(_PMs.var(pm, nw, cnd, :pt, arc), flow_lb)
+                JuMP.set_upper_bound(_PMs.var(pm, nw, cnd, :pt, arc), flow_ub)
             end
         end
     end
@@ -166,20 +166,20 @@ end
 
 
 "Create variables for the reactive power flowing into all transformer windings."
-function variable_tp_trans_reactive_flow(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
-    for cnd in PMs.conductor_ids(pm)
-        PMs.var(pm, nw, cnd)[:qt] = JuMP.@variable(pm.model,
-            [(l,i,j) in PMs.ref(pm, nw, :arcs_trans)],
+function variable_tp_trans_reactive_flow(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+    for cnd in _PMs.conductor_ids(pm)
+        _PMs.var(pm, nw, cnd)[:qt] = JuMP.@variable(pm.model,
+            [(l,i,j) in _PMs.ref(pm, nw, :arcs_trans)],
             base_name="$(nw)_$(cnd)_q_trans",
             start=0
         )
         if bounded
-            for arc in PMs.ref(pm, nw, :arcs_trans)
+            for arc in _PMs.ref(pm, nw, :arcs_trans)
                 tr_id = arc[1]
-                flow_lb  = -PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                flow_ub  = PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                JuMP.set_lower_bound(PMs.var(pm, nw, cnd, :qt, arc), flow_lb)
-                JuMP.set_upper_bound(PMs.var(pm, nw, cnd, :qt, arc), flow_ub)
+                flow_lb  = -_PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_ub  = _PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                JuMP.set_lower_bound(_PMs.var(pm, nw, cnd, :qt, arc), flow_lb)
+                JuMP.set_upper_bound(_PMs.var(pm, nw, cnd, :qt, arc), flow_ub)
             end
         end
     end
@@ -187,19 +187,19 @@ end
 
 
 "Create tap variables."
-function variable_tp_oltc_tap(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, bounded=true)
+function variable_tp_oltc_tap(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, bounded=true)
     nphases = 3
-    oltc_ids = PMs.ids(pm, pm.cnw, :trans)
+    oltc_ids = _PMs.ids(pm, pm.cnw, :trans)
     for c in 1:nphases
-        PMs.var(pm, nw, c)[:tap] = JuMP.@variable(pm.model,
+        _PMs.var(pm, nw, c)[:tap] = JuMP.@variable(pm.model,
             [i in oltc_ids],
             base_name="$(nw)_tm",
-            start=PMs.ref(pm, nw, :trans, i, "tm")[c]
+            start=_PMs.ref(pm, nw, :trans, i, "tm")[c]
         )
         if bounded
             for tr_id in oltc_ids
-                JuMP.set_lower_bound(PMs.var(pm, nw, c)[:tap][tr_id], PMs.ref(pm, nw, :trans, tr_id, "tm_min")[c])
-                JuMP.set_upper_bound(PMs.var(pm, nw, c)[:tap][tr_id], PMs.ref(pm, nw, :trans, tr_id, "tm_max")[c])
+                JuMP.set_lower_bound(_PMs.var(pm, nw, c)[:tap][tr_id], _PMs.ref(pm, nw, :trans, tr_id, "tm_min")[c])
+                JuMP.set_upper_bound(_PMs.var(pm, nw, c)[:tap][tr_id], _PMs.ref(pm, nw, :trans, tr_id, "tm_max")[c])
             end
         end
     end

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -33,13 +33,13 @@ function variable_tp_voltage_magnitude_sqr(pm::PMs.GenericPowerModel; nw::Int=pm
             [i in bus_cnd], base_name="$(nw)_w",
             lower_bound = PMs.ref(pm, nw, :bus, i[1], "vmin", i[2])^2,
             upper_bound = PMs.ref(pm, nw, :bus, i[1], "vmax", i[2])^2,
-            start = PMs.getval(PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
         )
     else
         W = PMs.var(pm, nw)[:w] = JuMP.@variable(pm.model,
             [i in bus_cnd], base_name="$(nw)_w",
             lower_bound = 0,
-            start = PMs.getval(PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i[1]), "w_start", i[2], 1.001)
         )
     end
 
@@ -58,17 +58,17 @@ function variable_tp_voltage_product(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, 
 
     WR = PMs.var(pm, nw)[:wr] = JuMP.@variable(pm.model,
         [b in bus_cnd], base_name="$(nw)_wr",
-        start = PMs.getval(b[1] != b[2] ? PMs.ref(pm, nw, :buspairs, b[1:2]) : PMs.ref(pm, nw, :bus, b[1]), "wr_start", b[3], 1.0)
+        start = PMs. comp_start_value(b[1] != b[2] ? PMs.ref(pm, nw, :buspairs, b[1:2]) : PMs.ref(pm, nw, :bus, b[1]), "wr_start", b[3], 1.0)
     )
 
     WI = PMs.var(pm, nw)[:wi] = JuMP.@variable(pm.model,
         [b in bus_cnd], base_name="$(nw)_wi",
-        start = PMs.getval(b[1] != b[2] ? PMs.ref(pm, nw, :buspairs, b[1:2]) : PMs.ref(pm, nw, :bus, b[1]), "wi_start", b[3])
+        start = PMs. comp_start_value(b[1] != b[2] ? PMs.ref(pm, nw, :buspairs, b[1:2]) : PMs.ref(pm, nw, :bus, b[1]), "wi_start", b[3])
     )
 
     if bounded
         # Diagonal bounds
-        wr_min, wr_max, wi_min, wi_max = PMs.calc_voltage_product_bounds(PMs.ref(pm, nw, :buspairs), cnd)
+        wr_min, wr_max, wi_min, wi_max = PMs.ref_calc_voltage_product_bounds(PMs.ref(pm, nw, :buspairs), cnd)
         for (i, j) in PMs.ids(pm, nw, :buspairs)
             JuMP.set_upper_bound(WR[(i, j, cnd, cnd)], wr_max[(i,j)])
             JuMP.set_upper_bound(WI[(i, j, cnd, cnd)], wi_max[(i,j)])
@@ -124,7 +124,7 @@ end
 function variable_active_bus_power_slack(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     PMs.var(pm, nw, cnd)[:p_slack] = JuMP.@variable(pm.model,
         [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_p_slack",
-        start = PMs.getval(PMs.ref(pm, nw, :bus, i), "p_slack_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "p_slack_start", cnd)
     )
 end
 
@@ -133,7 +133,7 @@ end
 function variable_reactive_bus_power_slack(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     PMs.var(pm, nw, cnd)[:q_slack] = JuMP.@variable(pm.model,
         [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(cnd)_q_slack",
-        start = PMs.getval(PMs.ref(pm, nw, :bus, i), "q_slack_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "q_slack_start", cnd)
     )
 end
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -2,41 +2,41 @@
 
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_tp_voltage(pm::PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: PMs.AbstractACPForm
+function constraint_tp_model_voltage(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: _PMs.AbstractACPForm
 end
 
 
 ""
-function constraint_kcl_shunt_slack(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractACPForm
-    vm = PMs.var(pm, n, c, :vm, i)
-    p_slack = PMs.var(pm, n, c, :p_slack, i)
-    q_slack = PMs.var(pm, n, c, :q_slack, i)
-    p = PMs.var(pm, n, c, :p)
-    q = PMs.var(pm, n, c, :q)
-    pg = PMs.var(pm, n, c, :pg)
-    qg = PMs.var(pm, n, c, :qg)
-    p_dc = PMs.var(pm, n, c, :p_dc)
-    q_dc = PMs.var(pm, n, c, :q_dc)
+function constraint_tp_power_balance_shunt_slack(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractACPForm
+    vm = _PMs.var(pm, n, c, :vm, i)
+    p_slack = _PMs.var(pm, n, c, :p_slack, i)
+    q_slack = _PMs.var(pm, n, c, :q_slack, i)
+    p = _PMs.var(pm, n, c, :p)
+    q = _PMs.var(pm, n, c, :q)
+    pg = _PMs.var(pm, n, c, :pg)
+    qg = _PMs.var(pm, n, c, :qg)
+    p_dc = _PMs.var(pm, n, c, :p_dc)
+    q_dc = _PMs.var(pm, n, c, :q_dc)
 
-    PMs.con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2 + p_slack)
-    PMs.con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2 + q_slack)
+    _PMs.con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2 + p_slack)
+    _PMs.con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2 + q_slack)
 end
 
 
 ""
-function constraint_kcl_shunt_trans(pm::PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractACPForm
-    vm = PMs.var(pm, nw, c, :vm, i)
-    p = PMs.var(pm, nw, c, :p)
-    q = PMs.var(pm, nw, c, :q)
-    pg = PMs.var(pm, nw, c, :pg)
-    qg = PMs.var(pm, nw, c, :qg)
-    p_dc = PMs.var(pm, nw, c, :p_dc)
-    q_dc = PMs.var(pm, nw, c, :q_dc)
-    p_trans = PMs.var(pm, nw, c, :pt)
-    q_trans = PMs.var(pm,  nw, c, :qt)
+function constraint_tp_power_balance_shunt_trans(pm::_PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractACPForm
+    vm = _PMs.var(pm, nw, c, :vm, i)
+    p = _PMs.var(pm, nw, c, :p)
+    q = _PMs.var(pm, nw, c, :q)
+    pg = _PMs.var(pm, nw, c, :pg)
+    qg = _PMs.var(pm, nw, c, :qg)
+    p_dc = _PMs.var(pm, nw, c, :p_dc)
+    q_dc = _PMs.var(pm, nw, c, :q_dc)
+    p_trans = _PMs.var(pm, nw, c, :pt)
+    q_trans = _PMs.var(pm,  nw, c, :qt)
 
-    PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_trans[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_trans[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
 end
 
 
@@ -48,24 +48,24 @@ p[f_idx] ==  (g+g_fr)/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f
 q[f_idx] == -(b+b_fr)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus]))
 ```
 """
-function constraint_ohms_tp_yt_from(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractACPForm
-    p_fr  = PMs.var(pm, n, c,  :p, f_idx)
-    q_fr  = PMs.var(pm, n, c,  :q, f_idx)
-    vm_fr = [PMs.var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
-    vm_to = [PMs.var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
-    va_fr = [PMs.var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
-    va_to = [PMs.var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+function constraint_tp_ohms_yt_from(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: _PMs.AbstractACPForm
+    p_fr  = _PMs.var(pm, n, c,  :p, f_idx)
+    q_fr  = _PMs.var(pm, n, c,  :q, f_idx)
+    vm_fr = [_PMs.var(pm, n, d, :vm, f_bus) for d in _PMs.conductor_ids(pm)]
+    vm_to = [_PMs.var(pm, n, d, :vm, t_bus) for d in _PMs.conductor_ids(pm)]
+    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
+    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
 
     JuMP.@NLconstraint(pm.model, p_fr ==  (g_fr[c]+g[c,c]) * vm_fr[c]^2 +
                                     sum( g[c,d]*vm_fr[c]*vm_fr[d]*cos(va_fr[c]-va_fr[d]) +
-                                         b[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in PMs.conductor_ids(pm) if d != c) +
+                                         b[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in _PMs.conductor_ids(pm) if d != c) +
                                     sum(-g[c,d]*vm_fr[c]*vm_to[d]*cos(va_fr[c]-va_to[d]) +
-                                        -b[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in PMs.conductor_ids(pm)) )
+                                        -b[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in _PMs.conductor_ids(pm)) )
     JuMP.@NLconstraint(pm.model, q_fr == -(b_fr[c]+b[c,c]) *vm_fr[c]^2 -
                                     sum( b[c,d]*vm_fr[c]*vm_fr[d]*cos(va_fr[c]-va_fr[d]) -
-                                         g[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in PMs.conductor_ids(pm) if d != c) -
+                                         g[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in _PMs.conductor_ids(pm) if d != c) -
                                     sum(-b[c,d]*vm_fr[c]*vm_to[d]*cos(va_fr[c]-va_to[d]) +
-                                         g[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in PMs.conductor_ids(pm)) )
+                                         g[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in _PMs.conductor_ids(pm)) )
 end
 
 
@@ -77,24 +77,24 @@ p[t_idx] ==  (g+g_to)*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bu
 q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_tp_yt_to(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACPForm
-    p_to  = PMs.var(pm, n, c,  :p, t_idx)
-    q_to  = PMs.var(pm, n, c,  :q, t_idx)
-    vm_fr = [PMs.var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
-    vm_to = [PMs.var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
-    va_fr = [PMs.var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
-    va_to = [PMs.var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+function constraint_tp_ohms_yt_to(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: _PMs.AbstractACPForm
+    p_to  = _PMs.var(pm, n, c,  :p, t_idx)
+    q_to  = _PMs.var(pm, n, c,  :q, t_idx)
+    vm_fr = [_PMs.var(pm, n, d, :vm, f_bus) for d in _PMs.conductor_ids(pm)]
+    vm_to = [_PMs.var(pm, n, d, :vm, t_bus) for d in _PMs.conductor_ids(pm)]
+    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
+    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
 
     JuMP.@NLconstraint(pm.model, p_to == (g_to[c]+g[c,c])*vm_to[c]^2 +
                                    sum( g[c,d]*vm_to[c]*vm_to[d]*cos(va_to[c]-va_to[d]) +
-                                        b[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in PMs.conductor_ids(pm) if d != c) +
+                                        b[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in _PMs.conductor_ids(pm) if d != c) +
                                    sum(-g[c,d]*vm_to[c]*vm_fr[d]*cos(va_to[c]-va_fr[d]) +
-                                       -b[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in PMs.conductor_ids(pm)) )
+                                       -b[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in _PMs.conductor_ids(pm)) )
     JuMP.@NLconstraint(pm.model, q_to == -(b_to[c]+b[c,c])*vm_to[c]^2 -
                                    sum( b[c,d]*vm_to[c]*vm_to[d]*cos(va_to[c]-va_to[d]) -
-                                        g[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in PMs.conductor_ids(pm) if d != c) -
+                                        g[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in _PMs.conductor_ids(pm) if d != c) -
                                    sum(-b[c,d]*vm_to[c]*vm_fr[d]*cos(va_to[c]-va_fr[d]) +
-                                        g[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in PMs.conductor_ids(pm)) )
+                                        g[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in _PMs.conductor_ids(pm)) )
 end
 
 
@@ -104,25 +104,25 @@ p[f_idx] == z*(g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]
 q[f_idx] == z*(-(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus])))
 ```
 """
-function constraint_ohms_tp_yt_from_on_off(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
-    p_fr  = PMs.var(pm, n, c,  :p, f_idx)
-    q_fr  = PMs.var(pm, n, c,  :q, f_idx)
-    vm_fr = [PMs.var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
-    vm_to = [PMs.var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
-    va_fr = [PMs.var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
-    va_to = [PMs.var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
-    z = PMs.var(pm, n, c, :branch_z, i)
+function constraint_tp_ohms_yt_from_on_off(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: _PMs.AbstractACPForm
+    p_fr  = _PMs.var(pm, n, c,  :p, f_idx)
+    q_fr  = _PMs.var(pm, n, c,  :q, f_idx)
+    vm_fr = [_PMs.var(pm, n, d, :vm, f_bus) for d in _PMs.conductor_ids(pm)]
+    vm_to = [_PMs.var(pm, n, d, :vm, t_bus) for d in _PMs.conductor_ids(pm)]
+    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
+    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
+    z = _PMs.var(pm, n, c, :branch_z, i)
 
     JuMP.@NLconstraint(pm.model, p_fr == z*((g_fr[c]+g[c,c]) * vm_fr[c]^2 +
                                         sum( g[c,d]*vm_fr[c]*vm_fr[d]*cos(va_fr[c]-va_fr[d]) +
-                                             b[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in PMs.conductor_ids(pm) if d != c) +
+                                             b[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in _PMs.conductor_ids(pm) if d != c) +
                                         sum(-g[c,d]*vm_fr[c]*vm_to[d]*cos(va_fr[c]-va_to[d]) +
-                                            -b[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in PMs.conductor_ids(pm))) )
+                                            -b[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in _PMs.conductor_ids(pm))) )
     JuMP.@NLconstraint(pm.model, q_fr == z*(-(b_fr[c]+b[c,c]) *vm_fr[c]^2 -
                                         sum( b[c,d]*vm_fr[c]*vm_fr[d]*cos(va_fr[c]-va_fr[d]) -
-                                             g[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in PMs.conductor_ids(pm) if d != c) -
+                                             g[c,d]*vm_fr[c]*vm_fr[d]*sin(va_fr[c]-va_fr[d]) for d in _PMs.conductor_ids(pm) if d != c) -
                                         sum(-b[c,d]*vm_fr[c]*vm_to[d]*cos(va_fr[c]-va_to[d]) +
-                                             g[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in PMs.conductor_ids(pm))) )
+                                             g[c,d]*vm_fr[c]*vm_to[d]*sin(va_fr[c]-va_to[d]) for d in _PMs.conductor_ids(pm))) )
 end
 
 """
@@ -131,37 +131,37 @@ p[t_idx] == z*(g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[
 q[t_idx] == z*(-(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus])))
 ```
 """
-function constraint_ohms_tp_yt_to_on_off(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractACPForm
-    p_to  = PMs.var(pm, n, c,  :p, t_idx)
-    q_to  = PMs.var(pm, n, c,  :q, t_idx)
-    vm_fr = [PMs.var(pm, n, d, :vm, f_bus) for d in PMs.conductor_ids(pm)]
-    vm_to = [PMs.var(pm, n, d, :vm, t_bus) for d in PMs.conductor_ids(pm)]
-    va_fr = [PMs.var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
-    va_to = [PMs.var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
-    z = PMs.var(pm, n, c, :branch_z, i)
+function constraint_tp_ohms_yt_to_on_off(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: _PMs.AbstractACPForm
+    p_to  = _PMs.var(pm, n, c,  :p, t_idx)
+    q_to  = _PMs.var(pm, n, c,  :q, t_idx)
+    vm_fr = [_PMs.var(pm, n, d, :vm, f_bus) for d in _PMs.conductor_ids(pm)]
+    vm_to = [_PMs.var(pm, n, d, :vm, t_bus) for d in _PMs.conductor_ids(pm)]
+    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
+    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
+    z = _PMs.var(pm, n, c, :branch_z, i)
 
     JuMP.@NLconstraint(pm.model, p_to == z*((g_to[c]+g[c,c])*vm_to[c]^2 +
                                         sum( g[c,d]*vm_to[c]*vm_to[d]*cos(va_to[c]-va_to[d]) +
-                                             b[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in PMs.conductor_ids(pm) if d != c) +
+                                             b[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in _PMs.conductor_ids(pm) if d != c) +
                                         sum(-g[c,d]*vm_to[c]*vm_fr[d]*cos(va_to[c]-va_fr[d]) +
-                                            -b[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in PMs.conductor_ids(pm))) )
+                                            -b[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in _PMs.conductor_ids(pm))) )
     JuMP.@NLconstraint(pm.model, q_to == z*(-(b_to[c]+b[c,c])*vm_to[c]^2 -
                                         sum( b[c,d]*vm_to[c]*vm_to[d]*cos(va_to[c]-va_to[d]) -
-                                             g[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in PMs.conductor_ids(pm) if d != c) -
+                                             g[c,d]*vm_to[c]*vm_to[d]*sin(va_to[c]-va_to[d]) for d in _PMs.conductor_ids(pm) if d != c) -
                                         sum(-b[c,d]*vm_to[c]*vm_fr[d]*cos(va_to[c]-va_fr[d]) +
-                                             g[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in PMs.conductor_ids(pm))) )
+                                             g[c,d]*vm_to[c]*vm_fr[d]*sin(va_to[c]-va_fr[d]) for d in _PMs.conductor_ids(pm))) )
 end
 
 
 "Links the voltage at both windings of a fixed tap transformer."
-function constraint_tp_trans_voltage(pm::PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to) where T <: PMs.AbstractACPForm
+function constraint_tp_trans_voltage(pm::_PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to) where T <: _PMs.AbstractACPForm
     ncnd  = 3
     # from side
-    vm_fr = [PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
-    va_fr = [PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
+    vm_fr = [_PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
+    va_fr = [_PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
     # to side
-    vm_to = [PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
-    va_to = [PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
+    vm_to = [_PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
+    va_to = [_PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
     # the intermediate bus voltage is saved as an expression
     # vm_im[c] = vm_to[c]*tm[c]*Cv_to
     # va_im = va_to
@@ -179,18 +179,18 @@ end
 
 
 "Links the power flowing into both windings of a fixed tap transformer."
-function constraint_tp_trans_flow(pm::PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to) where T <: PMs.AbstractACPForm
+function constraint_tp_trans_flow(pm::_PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to) where T <: _PMs.AbstractACPForm
     ncnd  = 3
     # from side variables
-    vm_fr = [PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
-    va_fr = [PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
-    p_fr = [PMs.var(pm, nw, c, :pt, f_idx) for c in 1:ncnd]
-    q_fr = [PMs.var(pm, nw, c, :qt, f_idx) for c in 1:ncnd]
+    vm_fr = [_PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
+    va_fr = [_PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
+    p_fr = [_PMs.var(pm, nw, c, :pt, f_idx) for c in 1:ncnd]
+    q_fr = [_PMs.var(pm, nw, c, :qt, f_idx) for c in 1:ncnd]
     # to side
-    vm_to = [PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
-    va_to = [PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
-    p_to = [PMs.var(pm, nw, c, :pt, t_idx) for c in 1:ncnd]
-    q_to = [PMs.var(pm, nw, c, :qt, t_idx) for c in 1:ncnd]
+    vm_to = [_PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
+    va_to = [_PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
+    p_to = [_PMs.var(pm, nw, c, :pt, t_idx) for c in 1:ncnd]
+    q_to = [_PMs.var(pm, nw, c, :qt, t_idx) for c in 1:ncnd]
     # the intermediate bus voltage is saved as an expression
     # vm_im[c] = vm_to[c]*tm[c]*Cv_to
     # va_im = va_to
@@ -222,16 +222,16 @@ end
 
 
 "Links the voltage at both windings of a variable tap transformer."
-function constraint_tp_oltc_voltage(pm::PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, Tv_fr, Tv_im, Cv_to) where T <: PMs.AbstractACPForm
+function constraint_tp_oltc_voltage(pm::_PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, Tv_fr, Tv_im, Cv_to) where T <: _PMs.AbstractACPForm
     ncnd  = 3
     # from side
-    vm_fr = [PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
-    va_fr = [PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
+    vm_fr = [_PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
+    va_fr = [_PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
     # tap
-    tap = [PMs.var(pm, nw, c, :tap)[i] for c in 1:ncnd]
+    tap = [_PMs.var(pm, nw, c, :tap)[i] for c in 1:ncnd]
     # to side
-    vm_to = [PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
-    va_to = [PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
+    vm_to = [_PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
+    va_to = [_PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
     # the intermediate bus voltage is saved as an expression
     # vm_im[c] = vm_to[c]*tap[c]*Cv_to
     # va_im = va_to
@@ -249,20 +249,20 @@ end
 
 
 "Links the power flowing into both windings of a variable tap transformer."
-function constraint_tp_oltc_flow(pm::PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, Ti_fr, Ti_im, Cv_to) where T <: PMs.AbstractACPForm
+function constraint_tp_oltc_flow(pm::_PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, Ti_fr, Ti_im, Cv_to) where T <: _PMs.AbstractACPForm
     ncnd  = 3
     # from side variables
-    vm_fr = [PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
-    va_fr = [PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
-    p_fr = [PMs.var(pm, nw, c, :pt, f_idx) for c in 1:ncnd]
-    q_fr = [PMs.var(pm, nw, c, :qt, f_idx) for c in 1:ncnd]
+    vm_fr = [_PMs.var(pm, nw, c, :vm, f_bus) for c in 1:ncnd]
+    va_fr = [_PMs.var(pm, nw, c, :va, f_bus) for c in 1:ncnd]
+    p_fr = [_PMs.var(pm, nw, c, :pt, f_idx) for c in 1:ncnd]
+    q_fr = [_PMs.var(pm, nw, c, :qt, f_idx) for c in 1:ncnd]
     # tap
-    tap = [PMs.var(pm, nw, c, :tap, i) for c in 1:ncnd]
+    tap = [_PMs.var(pm, nw, c, :tap, i) for c in 1:ncnd]
     # to side
-    vm_to = [PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
-    va_to = [PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
-    p_to = [PMs.var(pm, nw, c, :pt, t_idx) for c in 1:ncnd]
-    q_to = [PMs.var(pm, nw, c, :qt, t_idx) for c in 1:ncnd]
+    vm_to = [_PMs.var(pm, nw, c, :vm, t_bus) for c in 1:ncnd]
+    va_to = [_PMs.var(pm, nw, c, :va, t_bus) for c in 1:ncnd]
+    p_to = [_PMs.var(pm, nw, c, :pt, t_idx) for c in 1:ncnd]
+    q_to = [_PMs.var(pm, nw, c, :qt, t_idx) for c in 1:ncnd]
     # the intermediate bus voltage is saved as an expression
     # vm_im[c] = vm_to[c]*tap[c]*Cv_to
     # va_im = va_to

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -2,9 +2,9 @@
 
 
 ""
-function variable_tp_voltage(pm::PMs.GenericPowerModel{T}; kwargs...) where T <: PMs.AbstractACRForm
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_voltage(pm, cnd=c; kwargs...)
+function variable_tp_voltage(pm::_PMs.GenericPowerModel{T}; kwargs...) where T <: _PMs.AbstractACRForm
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_voltage(pm, cnd=c; kwargs...)
     end
     # local infeasbility issues without proper initialization;
     # convergence issues start when the equivalent angles of the starting point
@@ -12,31 +12,31 @@ function variable_tp_voltage(pm::PMs.GenericPowerModel{T}; kwargs...) where T <:
     # this is the default behaviour of PMs, initialize all phases as (1,0)
     # the magnitude seems to have little effect on the convergence (>0.05)
     # updating the starting point to a balanced phasor does the job
-    ncnd = length(PMs.conductor_ids(pm))
+    ncnd = length(_PMs.conductor_ids(pm))
     theta = [_wrap_to_pi(2 * pi / ncnd * (1-c)) for c in 1:ncnd]
     vm = 1
     for c in 1:ncnd
         vr = vm*cos(theta[c])
         vi = vm*sin(theta[c])
-        for id in PMs.ids(pm, :bus)
-            JuMP.set_start_value(PMs.var(pm, pm.cnw, c, :vr, id), vr)
-            JuMP.set_start_value(PMs.var(pm, pm.cnw, c, :vi, id), vi)
+        for id in _PMs.ids(pm, :bus)
+            JuMP.set_start_value(_PMs.var(pm, pm.cnw, c, :vr, id), vr)
+            JuMP.set_start_value(_PMs.var(pm, pm.cnw, c, :vi, id), vi)
         end
     end
 end
 
 
 "delegate back to PowerModels"
-function constraint_tp_voltage(pm::PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: PMs.AbstractACRForm
-    PMs. constraint_model_voltage(pm, n, c)
+function constraint_tp_model_voltage(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: _PMs.AbstractACRForm
+    _PMs.constraint_model_voltage(pm, n, c)
 end
 
 
 "Creates phase angle constraints at reference buses"
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: PMs.AbstractACRForm
-    vr = PMs.var(pm, n, c, :vr, d)
-    vi = PMs.var(pm, n, c, :vi, d)
-    nconductors = length(PMs.conductor_ids(pm))
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: _PMs.AbstractACRForm
+    vr = _PMs.var(pm, n, c, :vr, d)
+    vi = _PMs.var(pm, n, c, :vi, d)
+    nconductors = length(_PMs.conductor_ids(pm))
     theta = _wrap_to_pi(2 * pi / nconductors * (1-c))
     # deal with cases first where tan(theta)==Inf or tan(theta)==0
     if theta == pi/2
@@ -64,38 +64,38 @@ end
 
 
 ""
-function constraint_kcl_shunt_slack(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractACRForm
-    vr = PMs.var(pm, n, c, :vr, i)
-    vi = PMs.var(pm, n, c, :vi, i)
-    p_slack = PMs.var(pm, n, c, :p_slack, i)
-    q_slack = PMs.var(pm, n, c, :q_slack, i)
-    p = PMs.var(pm, n, c, :p)
-    q = PMs.var(pm, n, c, :q)
-    pg = PMs.var(pm, n, c, :pg)
-    qg = PMs.var(pm, n, c, :qg)
-    p_dc = PMs.var(pm, n, c, :p_dc)
-    q_dc = PMs.var(pm, n, c, :q_dc)
+function constraint_tp_power_balance_shunt_slack(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractACRForm
+    vr = _PMs.var(pm, n, c, :vr, i)
+    vi = _PMs.var(pm, n, c, :vi, i)
+    p_slack = _PMs.var(pm, n, c, :p_slack, i)
+    q_slack = _PMs.var(pm, n, c, :q_slack, i)
+    p = _PMs.var(pm, n, c, :p)
+    q = _PMs.var(pm, n, c, :q)
+    pg = _PMs.var(pm, n, c, :pg)
+    qg = _PMs.var(pm, n, c, :qg)
+    p_dc = _PMs.var(pm, n, c, :p_dc)
+    q_dc = _PMs.var(pm, n, c, :q_dc)
 
-    PMs.con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2) + p_slack)
-    PMs.con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2) + q_slack)
+    _PMs.con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2) + p_slack)
+    _PMs.con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2) + q_slack)
 end
 
 
 ""
-function constraint_kcl_shunt_trans(pm::PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractACRForm
-    vr = PMs.var(pm, nw, c, :vr, i)
-    vi = PMs.var(pm, nw, c, :vi, i)
-    p = PMs.var(pm, nw, c, :p)
-    q = PMs.var(pm, nw, c, :q)
-    pg = PMs.var(pm, nw, c, :pg)
-    qg = PMs.var(pm, nw, c, :qg)
-    p_dc = PMs.var(pm, nw, c, :p_dc)
-    q_dc = PMs.var(pm, nw, c, :q_dc)
-    p_trans = PMs.var(pm, nw, c, :pt)
-    q_trans = PMs.var(pm,  nw, c, :qt)
+function constraint_tp_power_balance_shunt_trans(pm::_PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractACRForm
+    vr = _PMs.var(pm, nw, c, :vr, i)
+    vi = _PMs.var(pm, nw, c, :vi, i)
+    p = _PMs.var(pm, nw, c, :p)
+    q = _PMs.var(pm, nw, c, :q)
+    pg = _PMs.var(pm, nw, c, :pg)
+    qg = _PMs.var(pm, nw, c, :qg)
+    p_dc = _PMs.var(pm, nw, c, :p_dc)
+    q_dc = _PMs.var(pm, nw, c, :q_dc)
+    p_trans = _PMs.var(pm, nw, c, :pt)
+    q_trans = _PMs.var(pm,  nw, c, :qt)
 
-    PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2))
-    PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_trans[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2))
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2))
+    _PMs.con(pm, nw, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_trans[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2))
 end
 
 
@@ -106,30 +106,30 @@ Creates Ohms constraints (yt post fix indicates that Y and T values are in recta
 p_fr =  g_fr[c]*(vr_fr[c]^2+vi_fr[c]^2)+ sum(
                                      vr_fr[c]*(g[c,d]*(vr_fr[d]-vr_to[d])-b[c,d]*(vi_fr[d]-vi_to[d]))
                                     -vi_fr[c]*(-b[c,d]*(vr_fr[d]-vr_to[d])-g[c,d]*(vi_fr[d]-vi_to[d]))
-                                for d in PMs.conductor_ids(pm))
+                                for d in _PMs.conductor_ids(pm))
 q_fr =  -b_fr[c]*(vr_fr[c]^2+vi_fr[c]^2)+ sum(
                                         -vr_fr[c]*(b[c,d]*(vr_fr[d]-vr_to[d])+g[c,d]*(vi_fr[d]-vi_to[d]))
                                         +vi_fr[c]*(g[c,d]*(vr_fr[d]-vr_to[d])-b[c,d]*(vi_fr[d]-vi_to[d]))
-                                    for d in PMs.conductor_ids(pm))
+                                    for d in _PMs.conductor_ids(pm))
 ```
 """
-function constraint_ohms_tp_yt_from(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractACRForm
-    p_fr  = PMs.var(pm, n, c,  :p, f_idx)
-    q_fr  = PMs.var(pm, n, c,  :q, f_idx)
-    vr_fr = [PMs.var(pm, n, d, :vr, f_bus) for d in PMs.conductor_ids(pm)]
-    vr_to = [PMs.var(pm, n, d, :vr, t_bus) for d in PMs.conductor_ids(pm)]
-    vi_fr = [PMs.var(pm, n, d, :vi, f_bus) for d in PMs.conductor_ids(pm)]
-    vi_to = [PMs.var(pm, n, d, :vi, t_bus) for d in PMs.conductor_ids(pm)]
+function constraint_tp_ohms_yt_from(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: _PMs.AbstractACRForm
+    p_fr  = _PMs.var(pm, n, c,  :p, f_idx)
+    q_fr  = _PMs.var(pm, n, c,  :q, f_idx)
+    vr_fr = [_PMs.var(pm, n, d, :vr, f_bus) for d in _PMs.conductor_ids(pm)]
+    vr_to = [_PMs.var(pm, n, d, :vr, t_bus) for d in _PMs.conductor_ids(pm)]
+    vi_fr = [_PMs.var(pm, n, d, :vi, f_bus) for d in _PMs.conductor_ids(pm)]
+    vi_to = [_PMs.var(pm, n, d, :vi, t_bus) for d in _PMs.conductor_ids(pm)]
 
     JuMP.@NLconstraint(pm.model, p_fr ==  g_fr[c]*(vr_fr[c]^2+vi_fr[c]^2)+ sum(
                                              vr_fr[c]*(g[c,d]*(vr_fr[d]-vr_to[d])-b[c,d]*(vi_fr[d]-vi_to[d]))
                                             -vi_fr[c]*(-b[c,d]*(vr_fr[d]-vr_to[d])-g[c,d]*(vi_fr[d]-vi_to[d]))
-                                        for d in PMs.conductor_ids(pm))
+                                        for d in _PMs.conductor_ids(pm))
     )
     JuMP.@NLconstraint(pm.model, q_fr ==  -b_fr[c]*(vr_fr[c]^2+vi_fr[c]^2)+ sum(
                                             -vr_fr[c]*(b[c,d]*(vr_fr[d]-vr_to[d])+g[c,d]*(vi_fr[d]-vi_to[d]))
                                             +vi_fr[c]*(g[c,d]*(vr_fr[d]-vr_to[d])-b[c,d]*(vi_fr[d]-vi_to[d]))
-                                        for d in PMs.conductor_ids(pm))
+                                        for d in _PMs.conductor_ids(pm))
     )
 end
 
@@ -142,6 +142,6 @@ p[t_idx] ==  (g+g_to)*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bu
 q[t_idx] == -(b+b_to)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_tp_yt_to(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractACRForm
-    constraint_ohms_tp_yt_from(pm, n, c, t_bus, f_bus, t_idx, f_idx, g, b, g_to, b_to, tr, ti, tm)
+function constraint_tp_ohms_yt_to(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: _PMs.AbstractACRForm
+    constraint_tp_ohms_yt_from(pm, n, c, t_bus, f_bus, t_idx, f_idx, g, b, g_to, b_to, tr, ti, tm)
 end

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -28,7 +28,7 @@ end
 
 "delegate back to PowerModels"
 function constraint_tp_voltage(pm::PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: PMs.AbstractACRForm
-    PMs.constraint_voltage(pm, n, c)
+    PMs. constraint_model_voltage(pm, n, c)
 end
 
 

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -1,26 +1,26 @@
 ### generic features that apply to all active-power-only (apo) approximations
 
 "do nothing, no reactive power in this model"
-function variable_tp_trans_reactive_flow(pm::PMs.GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true) where T <: PMs.AbstractActivePowerFormulation
+function variable_tp_trans_reactive_flow(pm::_PMs.GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true) where T <: _PMs.AbstractActivePowerFormulation
 end
 
 ""
-function constraint_kcl_shunt_trans(pm::PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractActivePowerFormulation
-    pg   = PMs.var(pm, nw, c, :pg)
-    p    = PMs.var(pm, nw, c, :p)
-    p_dc = PMs.var(pm, nw, c, :p_dc)
-    p_trans = PMs.var(pm, nw, c, :pt)
+function constraint_tp_power_balance_shunt_trans(pm::_PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractActivePowerFormulation
+    pg   = _PMs.var(pm, nw, c, :pg)
+    p    = _PMs.var(pm, nw, c, :p)
+    p_dc = _PMs.var(pm, nw, c, :p_dc)
+    p_trans = _PMs.var(pm, nw, c, :pt)
 
-    PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
+    _PMs.con(pm, nw, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
     # omit reactive constraint
 end
 
 
-function constraint_tp_storage_loss(pm::PMs.GenericPowerModel{T}, n::Int, i, bus, r, x, standby_loss) where T <: PMs.AbstractActivePowerFormulation
-    conductors = PMs.conductor_ids(pm)
-    ps = [PMs.var(pm, n, c, :ps, i) for c in conductors]
-    sc = PMs.var(pm, n, :sc, i)
-    sd = PMs.var(pm, n, :sd, i)
+function constraint_tp_storage_loss(pm::_PMs.GenericPowerModel{T}, n::Int, i, bus, r, x, standby_loss) where T <: _PMs.AbstractActivePowerFormulation
+    conductors = _PMs.conductor_ids(pm)
+    ps = [_PMs.var(pm, n, c, :ps, i) for c in conductors]
+    sc = _PMs.var(pm, n, :sc, i)
+    sd = _PMs.var(pm, n, :sd, i)
 
     JuMP.@NLconstraint(pm.model, sum(ps[c] for c in conductors) + (sd - sc) == standby_loss + sum( r[c]*ps[c]^2 for c in conductors) )
 end

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -1,14 +1,14 @@
 export LPLinUBFPowerModel, LPLinUBFForm
 
 "LinDist3Flow per Sankur et al 2016, using vector variables for power, voltage and current in scalar form"
-abstract type LPLinUBFForm <: PMs.AbstractBFForm end
+abstract type LPLinUBFForm <: _PMs.AbstractBFForm end
 
 ""
-const LPLinUBFPowerModel = PMs.GenericPowerModel{LPLinUBFForm}
+const LPLinUBFPowerModel = _PMs.GenericPowerModel{LPLinUBFForm}
 
 "default Lin3Distflow constructor for scalar form"
 LPLinUBFPowerModel(data::Dict{String,Any}; kwargs...) =
-    PMs.GenericPowerModel(data, LPLinUBFForm; kwargs...)
+    _PMs.GenericPowerModel(data, LPLinUBFForm; kwargs...)
 
 
 "rolls a 1d array left or right by idx"
@@ -29,13 +29,13 @@ end
 
 
 ""
-function variable_tp_voltage(pm::PMs.GenericPowerModel{T}; kwargs...) where T <: LPLinUBFForm
-    for cnd in PMs.conductor_ids(pm)
-        PMs.variable_voltage_magnitude_sqr(pm; cnd=cnd, kwargs...)
+function variable_tp_voltage(pm::_PMs.GenericPowerModel{T}; kwargs...) where T <: LPLinUBFForm
+    for cnd in _PMs.conductor_ids(pm)
+        _PMs.variable_voltage_magnitude_sqr(pm; cnd=cnd, kwargs...)
     end
 end
 
-function variable_tp_branch_current(pm::PMs.GenericPowerModel{T}; kwargs...) where T <: LPLinUBFForm
+function variable_tp_branch_current(pm::_PMs.GenericPowerModel{T}; kwargs...) where T <: LPLinUBFForm
     # nothing to do, variables not used in linearised branch flow model
 end
 
@@ -43,32 +43,32 @@ end
 """
 Defines voltage drop over a branch, linking from and to side voltage magnitude
 """
-function constraint_voltage_magnitude_difference(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
-    p_fr = [PMs.var(pm, n, d, :p, f_idx) for d in PMs.conductor_ids(pm)]
-    q_fr = [PMs.var(pm, n, d, :q, f_idx) for d in PMs.conductor_ids(pm)]
-    w_fr = PMs.var(pm, n, c, :w, f_bus)
-    w_to = PMs.var(pm, n, c, :w, t_bus)
+function constraint_tp_voltage_magnitude_difference(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
+    p_fr = [_PMs.var(pm, n, d, :p, f_idx) for d in _PMs.conductor_ids(pm)]
+    q_fr = [_PMs.var(pm, n, d, :q, f_idx) for d in _PMs.conductor_ids(pm)]
+    w_fr = _PMs.var(pm, n, c, :w, f_bus)
+    w_to = _PMs.var(pm, n, c, :w, t_bus)
 
-    np = length(PMs.conductor_ids(pm))
-    rot = roll([_wrap_to_pi(2*pi/np*(1-d)) for d in PMs.conductor_ids(pm)], c-1)
+    np = length(_PMs.conductor_ids(pm))
+    rot = roll([_wrap_to_pi(2*pi/np*(1-d)) for d in _PMs.conductor_ids(pm)], c-1)
 
     #KVL over the line:
     JuMP.@constraint(pm.model, w_to == w_fr - 2*sum((r[c,d]*cos(rot[d])-x[c,d]*sin(rot[d]))*(p_fr[d] - g_sh_fr*(w_fr/tm^2)) +
-                                               (r[c,d]*sin(rot[d])+x[c,d]*cos(rot[d]))*(q_fr[d] + b_sh_fr*(w_fr/tm^2)) for d in PMs.conductor_ids(pm)) )
+                                               (r[c,d]*sin(rot[d])+x[c,d]*cos(rot[d]))*(q_fr[d] + b_sh_fr*(w_fr/tm^2)) for d in _PMs.conductor_ids(pm)) )
 end
 
 ""
-function PMs.constraint_model_current(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
+function _PMs.constraint_model_current(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
 end
 
 
 """
 Defines branch flow model power flow loss equations
 """
-function constraint_tp_flow_losses(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to) where T <: LPLinUBFForm
+function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to) where T <: LPLinUBFForm
     tm = [1,1,1] #TODO
-    for c in PMs.conductor_ids(pm)
-        constraint_flow_losses(pm, n, c, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr[c,c], g_sh_to[c,c], b_sh_fr[c,c], b_sh_to[c,c], tm[c])
+    for c in _PMs.conductor_ids(pm)
+        constraint_tp_flow_losses(pm, n, c, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr[c,c], g_sh_to[c,c], b_sh_fr[c,c], b_sh_to[c,c], tm[c])
     end
 end
 
@@ -77,10 +77,10 @@ end
 """
 Defines branch flow model power flow equations
 """
-function constraint_tp_voltage_magnitude_difference(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
+function constraint_tp_model_voltage_magnitude_difference(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
     tm = [1,1,1] #TODO
-    for c in PMs.conductor_ids(pm)
-        constraint_voltage_magnitude_difference(pm, n, c, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr[c,c], b_sh_fr[c,c], tm[c])
+    for c in _PMs.conductor_ids(pm)
+        constraint_tp_voltage_magnitude_difference(pm, n, c, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr[c,c], b_sh_fr[c,c], tm[c])
     end
 end
 
@@ -89,13 +89,13 @@ end
 """
 Defines branch flow model power flow equations
 """
-function constraint_flow_losses(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm) where T <: LPLinUBFForm
-    p_fr = PMs.var(pm, n, c, :p, f_idx)
-    q_fr = PMs.var(pm, n, c, :q, f_idx)
-    p_to = PMs.var(pm, n, c, :p, t_idx)
-    q_to = PMs.var(pm, n, c, :q, t_idx)
-    w_fr = PMs.var(pm, n, c, :w, f_bus)
-    w_to = PMs.var(pm, n, c, :w, t_bus)
+function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm) where T <: LPLinUBFForm
+    p_fr = _PMs.var(pm, n, c, :p, f_idx)
+    q_fr = _PMs.var(pm, n, c, :q, f_idx)
+    p_to = _PMs.var(pm, n, c, :p, t_idx)
+    q_to = _PMs.var(pm, n, c, :q, t_idx)
+    w_fr = _PMs.var(pm, n, c, :w, f_bus)
+    w_to = _PMs.var(pm, n, c, :w, t_bus)
 
     JuMP.@constraint(pm.model, p_fr + p_to ==  g_sh_fr*(w_fr/tm^2) +  g_sh_to*w_to)
     JuMP.@constraint(pm.model, q_fr + q_to == -b_sh_fr*(w_fr/tm^2) + -b_sh_to*w_to)

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -58,7 +58,7 @@ function constraint_voltage_magnitude_difference(pm::PMs.GenericPowerModel{T}, n
 end
 
 ""
-function PMs.constraint_branch_current(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
+function PMs.constraint_model_current(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr, tm) where T <: LPLinUBFForm
 end
 
 

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -595,7 +595,7 @@ end
 ""
 function add_original_variables(sol, pm::PMs.GenericPowerModel)
     if !haskey(pm.setting, "output") || !haskey(pm.setting["output"], "branch_flows") || pm.setting["output"]["branch_flows"] == false
-        Memento.error(LOGGER, "deriving the original variables requires setting: branch_flows => true")
+        Memento.error(_LOGGER, "deriving the original variables requires setting: branch_flows => true")
     end
 
     for (nw, network) in pm.PMs.ref[:nw]

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -7,10 +7,10 @@ LPUBFForm, LPfullUBFPowerModel, LPfullUBFForm, LPdiagUBFPowerModel, LPdiagUBFFor
 SOCUBFForm, SOCConicUBFPowerModel, SOCNLPUBFPowerModel, SOCConicUBFForm, SOCNLPUBFForm
 
 ""
-abstract type AbstractNLPUBFForm <: PMs.AbstractBFQPForm end
+abstract type AbstractNLPUBFForm <: _PMs.AbstractBFQPForm end
 
 ""
-abstract type AbstractConicUBFForm <: PMs.AbstractBFConicForm end
+abstract type AbstractConicUBFForm <: _PMs.AbstractBFConicForm end
 
 AbstractUBFForm = Union{AbstractNLPUBFForm, AbstractConicUBFForm}
 
@@ -39,50 +39,50 @@ abstract type LPdiagUBFForm <: AbstractLPUBFForm end
 
 
 ""
-const SDPUBFPowerModel = PMs.GenericPowerModel{SDPUBFForm}
+const SDPUBFPowerModel = _PMs.GenericPowerModel{SDPUBFForm}
 
 "default SDP unbalanced DistFlow constructor"
 SDPUBFPowerModel(data::Dict{String,Any}; kwargs...) =
-PMs.GenericPowerModel(data, SDPUBFForm; kwargs...)
+_PMs.GenericPowerModel(data, SDPUBFForm; kwargs...)
 
 ""
-const SOCNLPUBFPowerModel = PMs.GenericPowerModel{SOCNLPUBFForm}
+const SOCNLPUBFPowerModel = _PMs.GenericPowerModel{SOCNLPUBFForm}
 
 "default SOC unbalanced DistFlow constructor"
 SOCNLPUBFPowerModel(data::Dict{String,Any}; kwargs...) =
-PMs.GenericPowerModel(data, SOCNLPUBFForm; kwargs...)
+_PMs.GenericPowerModel(data, SOCNLPUBFForm; kwargs...)
 
 ""
-const SOCConicUBFPowerModel = PMs.GenericPowerModel{SOCConicUBFForm}
+const SOCConicUBFPowerModel = _PMs.GenericPowerModel{SOCConicUBFForm}
 
 "default SOC unbalanced DistFlow constructor"
 SOCConicUBFPowerModel(data::Dict{String,Any}; kwargs...) =
-PMs.GenericPowerModel(data, SOCConicUBFForm; kwargs...)
+_PMs.GenericPowerModel(data, SOCConicUBFForm; kwargs...)
 
 ""
-const LPfullUBFPowerModel = PMs.GenericPowerModel{LPfullUBFForm}
+const LPfullUBFPowerModel = _PMs.GenericPowerModel{LPfullUBFForm}
 
 "default LP unbalanced DistFlow constructor"
 LPfullUBFPowerModel(data::Dict{String,Any}; kwargs...) =
-PMs.GenericPowerModel(data, LPfullUBFForm; kwargs...)
+_PMs.GenericPowerModel(data, LPfullUBFForm; kwargs...)
 
 ""
-const LPdiagUBFPowerModel = PMs.GenericPowerModel{LPdiagUBFForm}
+const LPdiagUBFPowerModel = _PMs.GenericPowerModel{LPdiagUBFForm}
 
 "default LP unbalanced DistFlow constructor"
 LPdiagUBFPowerModel(data::Dict{String,Any}; kwargs...) =
-PMs.GenericPowerModel(data, LPdiagUBFForm; kwargs...)
+_PMs.GenericPowerModel(data, LPdiagUBFForm; kwargs...)
 
-function variable_tp_branch_current(pm::PMs.GenericPowerModel{T}; kwargs...) where T <: AbstractUBFForm
+function variable_tp_branch_current(pm::_PMs.GenericPowerModel{T}; kwargs...) where T <: AbstractUBFForm
     variable_tp_branch_series_current_prod_hermitian(pm; kwargs...)
 end
 
-function variable_tp_voltage(pm::PMs.GenericPowerModel{T}; kwargs...) where T <: AbstractUBFForm
+function variable_tp_voltage(pm::_PMs.GenericPowerModel{T}; kwargs...) where T <: AbstractUBFForm
     variable_tp_voltage_prod_hermitian(pm; kwargs...)
 end
 
 ""
-function variable_tp_voltage_prod_hermitian(pm::PMs.GenericPowerModel{T}; n_cond::Int=3, nw::Int=pm.cnw, bounded = true) where T <: AbstractUBFForm
+function variable_tp_voltage_prod_hermitian(pm::_PMs.GenericPowerModel{T}; n_cond::Int=3, nw::Int=pm.cnw, bounded = true) where T <: AbstractUBFForm
     n_diag_el = n_cond
     n_lower_triangle_el = Int((n_cond^2 - n_cond)/2)
     for c in 1:n_diag_el
@@ -90,34 +90,34 @@ function variable_tp_voltage_prod_hermitian(pm::PMs.GenericPowerModel{T}; n_cond
     end
 
     wmaxdict = Dict{Int64, Any}()
-    for i in PMs.ids(pm, nw, :bus)
-        wmax = PMs.ref(pm, nw, :bus, i, "vmax").values*PMs.ref(pm, nw, :bus, i, "vmax").values'
+    for i in _PMs.ids(pm, nw, :bus)
+        wmax = _PMs.ref(pm, nw, :bus, i, "vmax").values*_PMs.ref(pm, nw, :bus, i, "vmax").values'
         wmaxltri = ThreePhasePowerModels._mat2ltrivec!(wmax)
         wmaxdict[i] = wmaxltri
     end
 
     for c in 1:n_lower_triangle_el
         if bounded
-            PMs.var(pm, nw, c)[:wr] = JuMP.@variable(pm.model,
-            [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wr",
+            _PMs.var(pm, nw, c)[:wr] = JuMP.@variable(pm.model,
+            [i in _PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wr",
             lower_bound = -wmaxdict[i][c],
             upper_bound =  wmaxdict[i][c],
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
-            PMs.var(pm, nw, c)[:wi] = JuMP.@variable(pm.model,
-            [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wi",
+            _PMs.var(pm, nw, c)[:wi] = JuMP.@variable(pm.model,
+            [i in _PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wi",
             lower_bound = -wmaxdict[i][c],
             upper_bound =  wmaxdict[i][c],
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
         else
-            PMs.var(pm, nw, c)[:wr] = JuMP.@variable(pm.model,
-            [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wr",
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            _PMs.var(pm, nw, c)[:wr] = JuMP.@variable(pm.model,
+            [i in _PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wr",
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
-            PMs.var(pm, nw, c)[:wi] = JuMP.@variable(pm.model,
-            [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wi",
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            _PMs.var(pm, nw, c)[:wi] = JuMP.@variable(pm.model,
+            [i in _PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wi",
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
         end
     end
@@ -125,22 +125,22 @@ function variable_tp_voltage_prod_hermitian(pm::PMs.GenericPowerModel{T}; n_cond
     #Store dictionary with matrix variables by bus
     w_re_dict = Dict{Int64, Any}()
     w_im_dict = Dict{Int64, Any}()
-    for i in PMs.ids(pm, nw, :bus)
-        w =  [PMs.var(pm, nw, h, :w,  i) for h in 1:n_diag_el]
-        wr = [PMs.var(pm, nw, h, :wr, i) for h in 1:n_lower_triangle_el]
-        wi = [PMs.var(pm, nw, h, :wi, i) for h in 1:n_lower_triangle_el]
+    for i in _PMs.ids(pm, nw, :bus)
+        w =  [_PMs.var(pm, nw, h, :w,  i) for h in 1:n_diag_el]
+        wr = [_PMs.var(pm, nw, h, :wr, i) for h in 1:n_lower_triangle_el]
+        wi = [_PMs.var(pm, nw, h, :wi, i) for h in 1:n_lower_triangle_el]
 
         (w_re, w_im) = _make_hermitian_matrix_variable(w, wr, wi)
         w_re_dict[i] = w_re
         w_im_dict[i] = w_im
     end
-    PMs.var(pm, nw)[:W_re] = w_re_dict
-    PMs.var(pm, nw)[:W_im] = w_im_dict
+    _PMs.var(pm, nw)[:W_re] = w_re_dict
+    _PMs.var(pm, nw)[:W_im] = w_im_dict
 end
 
-function variable_tp_branch_series_current_prod_hermitian(pm::PMs.GenericPowerModel{T}; n_cond::Int=3, nw::Int=pm.cnw, bounded = true) where T <: AbstractUBFForm
-    branches = PMs.ref(pm, nw, :branch)
-    buses = PMs.ref(pm, nw, :bus)
+function variable_tp_branch_series_current_prod_hermitian(pm::_PMs.GenericPowerModel{T}; n_cond::Int=3, nw::Int=pm.cnw, bounded = true) where T <: AbstractUBFForm
+    branches = _PMs.ref(pm, nw, :branch)
+    buses = _PMs.ref(pm, nw, :bus)
 
     n_diag_el = n_cond
     n_lower_triangle_el = Int((n_cond^2 - n_cond)/2)
@@ -170,17 +170,17 @@ function variable_tp_branch_series_current_prod_hermitian(pm::PMs.GenericPowerMo
 
     for c in 1:n_diag_el
         if bounded
-            PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
-            [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
+            _PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
+            [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
             lower_bound = 0,
             upper_bound = (cmax[l][c])^2,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
             )
         else
-            PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
-            [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
+            _PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
+            [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
             lower_bound = 0,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
         end
         # PowerModels.variable_current_magnitude_sqr(pm, nw=nw, cnd=c)
@@ -188,28 +188,28 @@ function variable_tp_branch_series_current_prod_hermitian(pm::PMs.GenericPowerMo
 
     for c in 1:n_lower_triangle_el
         if bounded
-            PMs.var(pm, nw, c)[:ccmr] = JuMP.@variable(pm.model,
-            [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmr",
+            _PMs.var(pm, nw, c)[:ccmr] = JuMP.@variable(pm.model,
+            [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmr",
             lower_bound = -(cmax[l][c])^2,
             upper_bound = (cmax[l][c])^2,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
             )
-            PMs.var(pm, nw, c)[:ccmi] = JuMP.@variable(pm.model,
-            [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmi",
+            _PMs.var(pm, nw, c)[:ccmi] = JuMP.@variable(pm.model,
+            [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmi",
             lower_bound = -(cmax[l][c])^2,
             upper_bound = (cmax[l][c])^2,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
         else
-            PMs.var(pm, nw, c)[:ccmr] = JuMP.@variable(pm.model,
-            [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmr",
+            _PMs.var(pm, nw, c)[:ccmr] = JuMP.@variable(pm.model,
+            [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmr",
             # lower_bound = 0,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
-            PMs.var(pm, nw, c)[:ccmi] = JuMP.@variable(pm.model,
-            [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmi",
+            _PMs.var(pm, nw, c)[:ccmi] = JuMP.@variable(pm.model,
+            [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmi",
             # lower_bound = 0,
-            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
         end
     end
@@ -217,48 +217,48 @@ function variable_tp_branch_series_current_prod_hermitian(pm::PMs.GenericPowerMo
     #Store dictionary with matrix variables by branch
     ccm_re_dict = Dict{Int64, Any}()
     ccm_im_dict = Dict{Int64, Any}()
-    for i in PMs.ids(pm, nw, :branch)
-        ccm =  [PMs.var(pm, nw, h, :cm,  i) for h in 1:n_diag_el]
-        ccmr = [PMs.var(pm, nw, h, :ccmr, i) for h in 1:n_lower_triangle_el]
-        ccmi = [PMs.var(pm, nw, h, :ccmi, i) for h in 1:n_lower_triangle_el]
+    for i in _PMs.ids(pm, nw, :branch)
+        ccm =  [_PMs.var(pm, nw, h, :cm,  i) for h in 1:n_diag_el]
+        ccmr = [_PMs.var(pm, nw, h, :ccmr, i) for h in 1:n_lower_triangle_el]
+        ccmi = [_PMs.var(pm, nw, h, :ccmi, i) for h in 1:n_lower_triangle_el]
 
         (ccm_re, ccm_im) = _make_hermitian_matrix_variable(ccm, ccmr, ccmi)
         ccm_re_dict[i] = ccm_re
         ccm_im_dict[i] = ccm_im
     end
-    PMs.var(pm, nw)[:CC_re] = ccm_re_dict
-    PMs.var(pm, nw)[:CC_im] = ccm_im_dict
+    _PMs.var(pm, nw)[:CC_re] = ccm_re_dict
+    _PMs.var(pm, nw)[:CC_im] = ccm_im_dict
 end
 
 ""
-function variable_tp_branch_flow(pm::PMs.GenericPowerModel{T}; n_cond::Int=3, nw::Int=pm.cnw, bounded = true) where T <: AbstractUBFForm
+function variable_tp_branch_flow(pm::_PMs.GenericPowerModel{T}; n_cond::Int=3, nw::Int=pm.cnw, bounded = true) where T <: AbstractUBFForm
     n_diag_el = n_cond
     n_lower_triangle_el = Int((n_cond^2 - n_cond)/2)
     @assert n_cond<=5
 
     for i in 1:n_diag_el
-        PMs.variable_active_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
-        PMs.variable_reactive_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
+        _PMs.variable_active_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
+        _PMs.variable_reactive_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
     end
 
     for i in 1:n_lower_triangle_el
-        variable_lower_triangle_active_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
-        variable_lower_triangle_reactive_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
-        variable_upper_triangle_active_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
-        variable_upper_triangle_reactive_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
+        variable_tp_lower_triangle_active_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
+        variable_tp_lower_triangle_reactive_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
+        variable_tp_upper_triangle_active_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
+        variable_tp_upper_triangle_reactive_branch_flow(pm, nw=nw, cnd=i, bounded=bounded)
     end
     #Store dictionary with matrix variables by arc
     p_mat_dict = Dict{Tuple{Int64,Int64,Int64}, Any}()
     q_mat_dict = Dict{Tuple{Int64,Int64,Int64}, Any}()
 
-    for i in PMs.ref(pm, nw, :arcs)
-        p_d =  [PMs.var(pm, nw, c, :p,    i) for c in 1:n_diag_el]
-        p_ut = [PMs.var(pm, nw, c, :p_ut, i) for c in 1:n_lower_triangle_el]
-        p_lt = [PMs.var(pm, nw, c, :p_lt, i) for c in 1:n_lower_triangle_el]
+    for i in _PMs.ref(pm, nw, :arcs)
+        p_d =  [_PMs.var(pm, nw, c, :p,    i) for c in 1:n_diag_el]
+        p_ut = [_PMs.var(pm, nw, c, :p_ut, i) for c in 1:n_lower_triangle_el]
+        p_lt = [_PMs.var(pm, nw, c, :p_lt, i) for c in 1:n_lower_triangle_el]
 
-        q_d =  [PMs.var(pm, nw, c, :q,    i) for c in 1:n_diag_el]
-        q_ut = [PMs.var(pm, nw, c, :q_ut, i) for c in 1:n_lower_triangle_el]
-        q_lt = [PMs.var(pm, nw, c, :q_lt, i) for c in 1:n_lower_triangle_el]
+        q_d =  [_PMs.var(pm, nw, c, :q,    i) for c in 1:n_diag_el]
+        q_ut = [_PMs.var(pm, nw, c, :q_ut, i) for c in 1:n_lower_triangle_el]
+        q_lt = [_PMs.var(pm, nw, c, :q_lt, i) for c in 1:n_lower_triangle_el]
 
         p_mat = _make_full_matrix_variable(p_d, p_lt, p_ut)
         q_mat = _make_full_matrix_variable(q_d, q_lt, q_ut)
@@ -266,116 +266,116 @@ function variable_tp_branch_flow(pm::PMs.GenericPowerModel{T}; n_cond::Int=3, nw
         p_mat_dict[i] = p_mat
         q_mat_dict[i] = q_mat
     end
-    PMs.var(pm, nw)[:P_mx] = p_mat_dict
-    PMs.var(pm, nw)[:Q_mx] = q_mat_dict
+    _PMs.var(pm, nw)[:P_mx] = p_mat_dict
+    _PMs.var(pm, nw)[:Q_mx] = q_mat_dict
 end
 
 
 "variable: `p_lt[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_lower_triangle_active_branch_flow(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
+function variable_tp_lower_triangle_active_branch_flow(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
     smaxdict = Dict{Tuple{Int64, Int64, Int64}, Any}()
 
-    for (l,i,j) in PMs.ref(pm, nw, :arcs)
-        cmax = PMs.ref(pm, nw, :branch, l, "rate_a").values./PMs.ref(pm, nw, :bus, i, "vmin").values
-        smax = PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
+    for (l,i,j) in _PMs.ref(pm, nw, :arcs)
+        cmax = _PMs.ref(pm, nw, :branch, l, "rate_a").values./_PMs.ref(pm, nw, :bus, i, "vmin").values
+        smax = _PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
         smaxltri = ThreePhasePowerModels._mat2ltrivec!(smax)
         smaxdict[(l,i,j)] = smaxltri
     end
 
     if bounded
-        PMs.var(pm, nw, cnd)[:p_lt] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_lt",
+        _PMs.var(pm, nw, cnd)[:p_lt] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_lt",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     else
-        PMs.var(pm, nw, cnd)[:p_lt] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_lt",
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        _PMs.var(pm, nw, cnd)[:p_lt] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_lt",
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     end
 end
 
 "variable: `q_lt[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_lower_triangle_reactive_branch_flow(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
+function variable_tp_lower_triangle_reactive_branch_flow(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
     smaxdict = Dict{Tuple{Int64, Int64, Int64}, Any}()
 
-    for (l,i,j) in PMs.ref(pm, nw, :arcs)
-        cmax = PMs.ref(pm, nw, :branch, l, "rate_a").values./PMs.ref(pm, nw, :bus, i, "vmin").values
-        smax = PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
+    for (l,i,j) in _PMs.ref(pm, nw, :arcs)
+        cmax = _PMs.ref(pm, nw, :branch, l, "rate_a").values./_PMs.ref(pm, nw, :bus, i, "vmin").values
+        smax = _PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
         smaxltri = ThreePhasePowerModels._mat2ltrivec!(smax)
         smaxdict[(l,i,j)] = smaxltri
     end
 
     if bounded
-        PMs.var(pm, nw, cnd)[:q_lt] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_lt",
+        _PMs.var(pm, nw, cnd)[:q_lt] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_lt",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     else
-        PMs.var(pm, nw, cnd)[:q_lt] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_lt",
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        _PMs.var(pm, nw, cnd)[:q_lt] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_lt",
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     end
 end
 
 "variable: `p_ut[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_upper_triangle_active_branch_flow(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
+function variable_tp_upper_triangle_active_branch_flow(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
     smaxdict = Dict{Tuple{Int64, Int64, Int64}, Any}()
 
-    for (l,i,j) in PMs.ref(pm, nw, :arcs)
-        cmax = PMs.ref(pm, nw, :branch, l, "rate_a").values./PMs.ref(pm, nw, :bus, i, "vmin").values
-        smax = PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
+    for (l,i,j) in _PMs.ref(pm, nw, :arcs)
+        cmax = _PMs.ref(pm, nw, :branch, l, "rate_a").values./_PMs.ref(pm, nw, :bus, i, "vmin").values
+        smax = _PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
         smaxutri = ThreePhasePowerModels._mat2utrivec!(smax)
         smaxdict[(l,i,j)] = smaxutri
     end
 
     if bounded
-        PMs.var(pm, nw, cnd)[:p_ut] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_ut",
+        _PMs.var(pm, nw, cnd)[:p_ut] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_ut",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     else
-        PMs.var(pm, nw, cnd)[:p_ut] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_ut",
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        _PMs.var(pm, nw, cnd)[:p_ut] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_ut",
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     end
 end
 
 "variable: `q_ut[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_upper_triangle_reactive_branch_flow(pm::PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
+function variable_tp_upper_triangle_reactive_branch_flow(pm::_PMs.GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
     smaxdict = Dict{Tuple{Int64, Int64, Int64}, Any}()
 
-    for (l,i,j) in PMs.ref(pm, nw, :arcs)
-        cmax = PMs.ref(pm, nw, :branch, l, "rate_a").values./PMs.ref(pm, nw, :bus, i, "vmin").values
-        smax = PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
+    for (l,i,j) in _PMs.ref(pm, nw, :arcs)
+        cmax = _PMs.ref(pm, nw, :branch, l, "rate_a").values./_PMs.ref(pm, nw, :bus, i, "vmin").values
+        smax = _PMs.ref(pm, nw, :bus, i, "vmax").values.*cmax'
         smaxutri = ThreePhasePowerModels._mat2utrivec!(smax)
         smaxdict[(l,i,j)] = smaxutri
     end
     if bounded
-        PMs.var(pm, nw, cnd)[:q_ut] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_ut",
+        _PMs.var(pm, nw, cnd)[:q_ut] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_ut",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     else
-        PMs.var(pm, nw, cnd)[:q_ut] = JuMP.@variable(pm.model,
-        [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_ut",
-        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        _PMs.var(pm, nw, cnd)[:q_ut] = JuMP.@variable(pm.model,
+        [(l,i,j) in _PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_ut",
+        start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     end
 end
 
 ""
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel{T}, i::Int; nw::Int=pm.cnw) where T <: AbstractUBFForm
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel{T}, i::Int; nw::Int=pm.cnw) where T <: AbstractUBFForm
     constraint_tp_theta_ref(pm, nw, i)
 end
 
@@ -383,32 +383,32 @@ end
 """
 Defines branch flow model power flow equations
 """
-function constraint_tp_flow_losses(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to) where T <: AbstractUBFForm
-    p_to = PMs.var(pm, n, :P_mx)[t_idx]
-    q_to = PMs.var(pm, n, :Q_mx)[t_idx]
+function constraint_tp_flow_losses(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to) where T <: AbstractUBFForm
+    p_to = _PMs.var(pm, n, :P_mx)[t_idx]
+    q_to = _PMs.var(pm, n, :Q_mx)[t_idx]
 
-    p_fr = PMs.var(pm, n, :P_mx)[f_idx]
-    q_fr = PMs.var(pm, n, :Q_mx)[f_idx]
+    p_fr = _PMs.var(pm, n, :P_mx)[f_idx]
+    q_fr = _PMs.var(pm, n, :Q_mx)[f_idx]
 
-    w_to_re = PMs.var(pm, n, :W_re)[t_bus]
-    w_fr_re = PMs.var(pm, n, :W_re)[f_bus]
+    w_to_re = _PMs.var(pm, n, :W_re)[t_bus]
+    w_fr_re = _PMs.var(pm, n, :W_re)[f_bus]
 
-    w_to_im = PMs.var(pm, n, :W_im)[t_bus]
-    w_fr_im = PMs.var(pm, n, :W_im)[f_bus]
+    w_to_im = _PMs.var(pm, n, :W_im)[t_bus]
+    w_fr_im = _PMs.var(pm, n, :W_im)[f_bus]
 
-    ccm_re =  PMs.var(pm, n, :CC_re)[i]
-    ccm_im =  PMs.var(pm, n, :CC_im)[i]
+    ccm_re =  _PMs.var(pm, n, :CC_re)[i]
+    ccm_im =  _PMs.var(pm, n, :CC_im)[i]
 
     JuMP.@constraint(pm.model, p_fr + p_to .==  w_fr_re*(g_sh_fr)' + w_fr_im*(b_sh_fr)' + r*ccm_re - x*ccm_im +  w_to_re*(g_sh_to)'  + w_to_im*(b_sh_to)')
     JuMP.@constraint(pm.model, q_fr + q_to .==  w_fr_im*(g_sh_fr)' - w_fr_re*(b_sh_fr)' + x*ccm_re + r*ccm_im +  w_to_im*(g_sh_to)'  - w_to_re*(b_sh_to)')
 end
 
 ""
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel{T}, n::Int, i) where T <: AbstractUBFForm
-    nconductors = length(PMs.conductor_ids(pm))
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel{T}, n::Int, i) where T <: AbstractUBFForm
+    nconductors = length(_PMs.conductor_ids(pm))
 
-    w_re = PMs.var(pm, n, :W_re)[i]
-    w_im = PMs.var(pm, n, :W_im)[i]
+    w_re = _PMs.var(pm, n, :W_re)[i]
+    w_im = _PMs.var(pm, n, :W_im)[i]
 
     alpha = exp(-im*ThreePhasePowerModels._wrap_to_pi(2 * pi / nconductors ))
     beta = (alpha*ones(nconductors)).^(0:nconductors-1)
@@ -425,21 +425,21 @@ end
 """
 Defines voltage drop over a branch, linking from and to side voltage
 """
-function constraint_tp_voltage_magnitude_difference(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: AbstractUBFForm
-    w_fr_re = PMs.var(pm, n, :W_re)[f_bus]
-    w_fr_im = PMs.var(pm, n, :W_im)[f_bus]
+function constraint_tp_model_voltage_magnitude_difference(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm) where T <: AbstractUBFForm
+    w_fr_re = _PMs.var(pm, n, :W_re)[f_bus]
+    w_fr_im = _PMs.var(pm, n, :W_im)[f_bus]
 
-    w_to_re = PMs.var(pm, n, :W_re)[t_bus]
-    w_to_im = PMs.var(pm, n, :W_im)[t_bus]
+    w_to_re = _PMs.var(pm, n, :W_re)[t_bus]
+    w_to_im = _PMs.var(pm, n, :W_im)[t_bus]
 
-    p_fr = PMs.var(pm, n, :P_mx)[f_idx]
-    q_fr = PMs.var(pm, n, :Q_mx)[f_idx]
+    p_fr = _PMs.var(pm, n, :P_mx)[f_idx]
+    q_fr = _PMs.var(pm, n, :Q_mx)[f_idx]
 
     p_s_fr = p_fr - (w_fr_re*(g_sh_fr)' + w_fr_im*(b_sh_fr)')
     q_s_fr = q_fr - (w_fr_im*(g_sh_fr)' - w_fr_re*(b_sh_fr)')
 
-    ccm_re =  PMs.var(pm, n, :CC_re)[i]
-    ccm_im =  PMs.var(pm, n, :CC_im)[i]
+    ccm_re =  _PMs.var(pm, n, :CC_re)[i]
+    ccm_im =  _PMs.var(pm, n, :CC_im)[i]
 
     #KVL over the line:
     JuMP.@constraint(pm.model, diag(w_to_re) .== diag(
@@ -454,84 +454,84 @@ function constraint_tp_voltage_magnitude_difference(pm::PMs.GenericPowerModel{T}
 end
 
 ""
-function get_solution_tp(pm::PMs.GenericPowerModel, sol::Dict{String,Any})
-    add_bus_voltage_setpoint(sol, pm)
-    PMs.add_setpoint_generator_power!(sol, pm)
-    add_branch_flow_setpoint(sol, pm)
-    add_branch_current_setpoint(sol, pm)
-    PMs.add_setpoint_dcline_flow!(sol, pm)
+function get_solution_tp(pm::_PMs.GenericPowerModel, sol::Dict{String,Any})
+    add_bus_voltage_setpoint!(sol, pm)
+    _PMs.add_setpoint_generator_power!(sol, pm)
+    add_branch_flow_setpoint!(sol, pm)
+    add_branch_current_setpoint!(sol, pm)
+    _PMs.add_setpoint_dcline_flow!(sol, pm)
 
-    PMs.add_dual_kcl!(sol, pm)
-    PMs.add_dual_sm!(sol, pm) # Adds the duals of the transmission lines' thermal limits.
+    _PMs.add_dual_kcl!(sol, pm)
+    _PMs.add_dual_sm!(sol, pm) # Adds the duals of the transmission lines' thermal limits.
 
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "original_variables") && pm.setting["output"]["original_variables"] == true
-        add_rank(sol, pm)
-        add_is_ac_feasible(sol, pm)
-        add_original_variables(sol, pm)
+        add_rank!(sol, pm)
+        add_is_ac_feasible!(sol, pm)
+        add_original_variables!(sol, pm)
     end
 end
 
 
 ""
-function add_bus_voltage_setpoint(sol, pm::PMs.GenericPowerModel)
-    PMs. add_setpoint!(sol, pm, "bus", "vm", :w; scale = (x,item,i) -> sqrt(x), status_name="bus_type", inactive_status_value=4)
-    PMs. add_setpoint!(sol, pm, "bus", "w",  :w, status_name="bus_type", inactive_status_value=4)
-    PMs. add_setpoint!(sol, pm, "bus", "wr", :wr, status_name="bus_type", inactive_status_value=4)
-    PMs. add_setpoint!(sol, pm, "bus", "wi", :wi, status_name="bus_type", inactive_status_value=4)
+function add_bus_voltage_setpoint!(sol, pm::_PMs.GenericPowerModel)
+    _PMs.add_setpoint!(sol, pm, "bus", "vm", :w; scale = (x,item,i) -> sqrt(x), status_name="bus_type", inactive_status_value=4)
+    _PMs.add_setpoint!(sol, pm, "bus", "w",  :w, status_name="bus_type", inactive_status_value=4)
+    _PMs.add_setpoint!(sol, pm, "bus", "wr", :wr, status_name="bus_type", inactive_status_value=4)
+    _PMs.add_setpoint!(sol, pm, "bus", "wi", :wi, status_name="bus_type", inactive_status_value=4)
 end
 
 ""
-function add_branch_flow_setpoint(sol, pm::PMs.GenericPowerModel)
+function add_branch_flow_setpoint!(sol, pm::_PMs.GenericPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
-        PMs. add_setpoint!(sol, pm, "branch", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "pf_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "qf_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "pf_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "qf_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pf_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qf_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pf_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qf_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
 
-        PMs. add_setpoint!(sol, pm, "branch", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "pt_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "qt_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "pt_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "qt_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pt_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qt_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "pt_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "qt_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
 
     end
 end
 
 
 ""
-function add_branch_current_setpoint(sol, pm::PMs.GenericPowerModel)
+function add_branch_current_setpoint!(sol, pm::_PMs.GenericPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
-        PMs. add_setpoint!(sol, pm, "branch", "cm", :cm; scale = (x,item,i) -> sqrt(x), status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "cc", :cm, status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "ccr", :ccmr, status_name="br_status")
-        PMs. add_setpoint!(sol, pm, "branch", "cci", :ccmi, status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "cm", :cm; scale = (x,item,i) -> sqrt(x), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "cc", :cm, status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "ccr", :ccmr, status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "cci", :ccmi, status_name="br_status")
     end
 end
 
 
-function add_rank(sol, pm::PMs.GenericPowerModel; tol = 1e-6)
-    add_voltage_variable_rank(sol, pm; tol=tol)
-    add_current_variable_rank(sol, pm; tol=tol)
-    add_branch_flow_rank(sol, pm; tol=tol)
+function add_rank!(sol, pm::_PMs.GenericPowerModel; tol = 1e-6)
+    add_voltage_variable_rank!(sol, pm; tol=tol)
+    add_current_variable_rank!(sol, pm; tol=tol)
+    add_branch_flow_rank!(sol, pm; tol=tol)
 end
 
-function add_voltage_variable_rank(sol, pm::PMs.GenericPowerModel; tol = 1e-6)
+function add_voltage_variable_rank!(sol, pm::_PMs.GenericPowerModel; tol = 1e-6)
 end
 
-function add_current_variable_rank(sol, pm::PMs.GenericPowerModel; tol = 1e-6)
+function add_current_variable_rank!(sol, pm::_PMs.GenericPowerModel; tol = 1e-6)
 end
 
-function add_branch_flow_rank(sol, pm::PMs.GenericPowerModel; tol = 1e-6)
+function add_branch_flow_rank!(sol, pm::_PMs.GenericPowerModel; tol = 1e-6)
 end
 
-function add_is_ac_feasible(sol, pm::PMs.GenericPowerModel)
+function add_is_ac_feasible!(sol, pm::_PMs.GenericPowerModel)
 end
 
-function add_is_ac_feasible(sol, pm::PMs.GenericPowerModel{T}) where T <: AbstractUBFForm
-    for (nw, network) in pm.PMs.ref[:nw]
+function add_is_ac_feasible!(sol, pm::_PMs.GenericPowerModel{T}) where T <: AbstractUBFForm
+    for (nw, network) in pm._PMs.ref[:nw]
         branch_feasibilities = [branch["rank"] <= 1 for (b, branch) in sol["branch"]]
         branch_feasbility = all(branch_feasibilities)
         bus_feasibilities = [bus["rank"] <= 1 for (b, bus) in sol["bus"]]
@@ -542,9 +542,9 @@ function add_is_ac_feasible(sol, pm::PMs.GenericPowerModel{T}) where T <: Abstra
     end
 end
 
-function add_voltage_variable_rank(sol, pm::PMs.GenericPowerModel{T}; tol = 1e-6) where T <: AbstractUBFForm
-    for (nw, network) in pm.PMs.ref[:nw]
-        buses       = PMs.ref(pm, nw, :bus)
+function add_voltage_variable_rank!(sol, pm::_PMs.GenericPowerModel{T}; tol = 1e-6) where T <: AbstractUBFForm
+    for (nw, network) in pm._PMs.ref[:nw]
+        buses       = _PMs.ref(pm, nw, :bus)
         for (b, bus) in buses
             Wre, Wim = _make_hermitian_matrix_variable(sol["bus"]["$b"]["w"].values, sol["bus"]["$b"]["wr"].values, sol["bus"]["$b"]["wi"].values)
             W = Wre + im*Wim
@@ -553,9 +553,9 @@ function add_voltage_variable_rank(sol, pm::PMs.GenericPowerModel{T}; tol = 1e-6
     end
 end
 
-function add_current_variable_rank(sol, pm::PMs.GenericPowerModel{T}; tol = 1e-6) where T <: AbstractUBFForm
-    for (nw, network) in pm.PMs.ref[:nw]
-        branches       = PMs.ref(pm, nw, :branch)
+function add_current_variable_rank!(sol, pm::_PMs.GenericPowerModel{T}; tol = 1e-6) where T <: AbstractUBFForm
+    for (nw, network) in pm._PMs.ref[:nw]
+        branches       = _PMs.ref(pm, nw, :branch)
         for (b, branch) in branches
             CCre, CCim = _make_hermitian_matrix_variable(sol["branch"]["$b"]["cc"].values, sol["branch"]["$b"]["ccr"].values, sol["branch"]["$b"]["cci"].values)
             CC = CCre + im*CCim
@@ -564,10 +564,10 @@ function add_current_variable_rank(sol, pm::PMs.GenericPowerModel{T}; tol = 1e-6
     end
 end
 
-function add_branch_flow_rank(sol, pm::PMs.GenericPowerModel{T}; tol = 1e-6) where T <: AbstractUBFForm
-    for (nw, network) in pm.PMs.ref[:nw]
-        buses       = PMs.ref(pm, nw, :bus)
-        for (b, branch) in PMs.ref(pm, nw, :branch)
+function add_branch_flow_rank!(sol, pm::_PMs.GenericPowerModel{T}; tol = 1e-6) where T <: AbstractUBFForm
+    for (nw, network) in pm._PMs.ref[:nw]
+        buses       = _PMs.ref(pm, nw, :bus)
+        for (b, branch) in _PMs.ref(pm, nw, :branch)
             g_fr = diagm(0 => branch["g_fr"].values)
             b_fr = diagm(0 => branch["b_fr"].values)
             y_fr = g_fr + im* b_fr
@@ -593,23 +593,23 @@ end
 
 
 ""
-function add_original_variables(sol, pm::PMs.GenericPowerModel)
+function add_original_variables!(sol, pm::_PMs.GenericPowerModel)
     if !haskey(pm.setting, "output") || !haskey(pm.setting["output"], "branch_flows") || pm.setting["output"]["branch_flows"] == false
         Memento.error(_LOGGER, "deriving the original variables requires setting: branch_flows => true")
     end
 
-    for (nw, network) in pm.PMs.ref[:nw]
+    for (nw, network) in pm._PMs.ref[:nw]
         #find rank-1 starting points
-        ref_buses   = find_ref_buses(pm, nw)
+        ref_buses   = _find_ref_buses(pm, nw)
         #TODO develop code to start with any rank-1 W variable
-        buses       = PMs.ref(pm, nw, :bus)
-        arcs        = PMs.ref(pm, nw, :arcs)
-        branches    = PMs.ref(pm, nw, :branch)
+        buses       = _PMs.ref(pm, nw, :bus)
+        arcs        = _PMs.ref(pm, nw, :arcs)
+        branches    = _PMs.ref(pm, nw, :branch)
         #define sets to explore
-        all_bus_ids             = Set([b for (b, bus)      in PMs.ref(pm, nw, :bus)])
-        all_arc_from_ids        = Set([(l,i,j) for (l,i,j) in PMs.ref(pm, nw, :arcs_from)])
-        all_arc_to_ids          = Set([(l,i,j) for (l,i,j) in PMs.ref(pm, nw, :arcs_to)])
-        all_branch_ids          = Set([l for (l,i,j)       in PMs.ref(pm, nw, :arcs_from)])
+        all_bus_ids             = Set([b for (b, bus)      in _PMs.ref(pm, nw, :bus)])
+        all_arc_from_ids        = Set([(l,i,j) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from)])
+        all_arc_to_ids          = Set([(l,i,j) for (l,i,j) in _PMs.ref(pm, nw, :arcs_to)])
+        all_branch_ids          = Set([l for (l,i,j)       in _PMs.ref(pm, nw, :arcs_from)])
         visited_arc_from_ids    = Set()
         visited_arc_to_ids      = Set()
         visited_bus_ids         = Set()
@@ -617,7 +617,7 @@ function add_original_variables(sol, pm::PMs.GenericPowerModel)
 
         for b in ref_buses
             sol["bus"]["$b"]["va"] = [0, -2*pi/3, 2*pi/3] #TODO support arbitrary angles at the reference bus
-            sol["bus"]["$b"]["vm"] = PMs.ref(pm, nw, :bus, b)["vm"].values
+            sol["bus"]["$b"]["vm"] = _PMs.ref(pm, nw, :bus, b)["vm"].values
             push!(visited_bus_ids, b)
         end
 

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -102,22 +102,22 @@ function variable_tp_voltage_prod_hermitian(pm::PMs.GenericPowerModel{T}; n_cond
             [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wr",
             lower_bound = -wmaxdict[i][c],
             upper_bound =  wmaxdict[i][c],
-            start = PMs.getval(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
             PMs.var(pm, nw, c)[:wi] = JuMP.@variable(pm.model,
             [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wi",
             lower_bound = -wmaxdict[i][c],
             upper_bound =  wmaxdict[i][c],
-            start = PMs.getval(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
         else
             PMs.var(pm, nw, c)[:wr] = JuMP.@variable(pm.model,
             [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wr",
-            start = PMs.getval(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
             PMs.var(pm, nw, c)[:wi] = JuMP.@variable(pm.model,
             [i in PMs.ids(pm, nw, :bus)], base_name="$(nw)_$(c)_wi",
-            start = PMs.getval(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :bus, i), "w_start", c, 1.001)
             )
         end
     end
@@ -174,13 +174,13 @@ function variable_tp_branch_series_current_prod_hermitian(pm::PMs.GenericPowerMo
             [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
             lower_bound = 0,
             upper_bound = (cmax[l][c])^2,
-            start = PMs.getval(PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
             )
         else
             PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
             [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
             lower_bound = 0,
-            start = PMs.getval(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
         end
         # PowerModels.variable_current_magnitude_sqr(pm, nw=nw, cnd=c)
@@ -192,24 +192,24 @@ function variable_tp_branch_series_current_prod_hermitian(pm::PMs.GenericPowerMo
             [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmr",
             lower_bound = -(cmax[l][c])^2,
             upper_bound = (cmax[l][c])^2,
-            start = PMs.getval(PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
             )
             PMs.var(pm, nw, c)[:ccmi] = JuMP.@variable(pm.model,
             [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmi",
             lower_bound = -(cmax[l][c])^2,
             upper_bound = (cmax[l][c])^2,
-            start = PMs.getval(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
         else
             PMs.var(pm, nw, c)[:ccmr] = JuMP.@variable(pm.model,
             [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmr",
             # lower_bound = 0,
-            start = PMs.getval(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
             PMs.var(pm, nw, c)[:ccmi] = JuMP.@variable(pm.model,
             [l in PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_ccmi",
             # lower_bound = 0,
-            start = PMs.getval(PMs.ref(pm, nw, :branch, l), "i_start", c)
+            start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "i_start", c)
             )
         end
     end
@@ -287,12 +287,12 @@ function variable_lower_triangle_active_branch_flow(pm::PMs.GenericPowerModel; n
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_lt",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     else
         PMs.var(pm, nw, cnd)[:p_lt] = JuMP.@variable(pm.model,
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_lt",
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     end
 end
@@ -313,12 +313,12 @@ function variable_lower_triangle_reactive_branch_flow(pm::PMs.GenericPowerModel;
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_lt",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     else
         PMs.var(pm, nw, cnd)[:q_lt] = JuMP.@variable(pm.model,
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_lt",
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     end
 end
@@ -339,12 +339,12 @@ function variable_upper_triangle_active_branch_flow(pm::PMs.GenericPowerModel; n
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_ut",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     else
         PMs.var(pm, nw, cnd)[:p_ut] = JuMP.@variable(pm.model,
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_p_ut",
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "p_start", cnd)
         )
     end
 end
@@ -364,12 +364,12 @@ function variable_upper_triangle_reactive_branch_flow(pm::PMs.GenericPowerModel;
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_ut",
         lower_bound = -smaxdict[(l,i,j)][cnd],
         upper_bound =  smaxdict[(l,i,j)][cnd],
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     else
         PMs.var(pm, nw, cnd)[:q_ut] = JuMP.@variable(pm.model,
         [(l,i,j) in PMs.ref(pm, nw, :arcs)], base_name="$(nw)_$(cnd)_q_ut",
-        start = PMs.getval(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
+        start = PMs. comp_start_value(PMs.ref(pm, nw, :branch, l), "q_start", cnd)
         )
     end
 end
@@ -456,13 +456,13 @@ end
 ""
 function get_solution_tp(pm::PMs.GenericPowerModel, sol::Dict{String,Any})
     add_bus_voltage_setpoint(sol, pm)
-    PMs.add_generator_power_setpoint(sol, pm)
+    PMs.add_setpoint_generator_power!(sol, pm)
     add_branch_flow_setpoint(sol, pm)
     add_branch_current_setpoint(sol, pm)
-    PMs.add_dcline_flow_setpoint(sol, pm)
+    PMs.add_setpoint_dcline_flow!(sol, pm)
 
-    PMs.add_kcl_duals(sol, pm)
-    PMs.add_sm_duals(sol, pm) # Adds the duals of the transmission lines' thermal limits.
+    PMs.add_dual_kcl!(sol, pm)
+    PMs.add_dual_sm!(sol, pm) # Adds the duals of the transmission lines' thermal limits.
 
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "original_variables") && pm.setting["output"]["original_variables"] == true
         add_rank(sol, pm)
@@ -474,28 +474,28 @@ end
 
 ""
 function add_bus_voltage_setpoint(sol, pm::PMs.GenericPowerModel)
-    PMs.add_setpoint(sol, pm, "bus", "vm", :w; scale = (x,item,i) -> sqrt(x))
-    PMs.add_setpoint(sol, pm, "bus", "w",  :w)
-    PMs.add_setpoint(sol, pm, "bus", "wr", :wr)
-    PMs.add_setpoint(sol, pm, "bus", "wi", :wi)
+    PMs. add_setpoint!(sol, pm, "bus", "vm", :w; scale = (x,item,i) -> sqrt(x), status_name="bus_type", inactive_status_value=4)
+    PMs. add_setpoint!(sol, pm, "bus", "w",  :w, status_name="bus_type", inactive_status_value=4)
+    PMs. add_setpoint!(sol, pm, "bus", "wr", :wr, status_name="bus_type", inactive_status_value=4)
+    PMs. add_setpoint!(sol, pm, "bus", "wi", :wi, status_name="bus_type", inactive_status_value=4)
 end
 
 ""
 function add_branch_flow_setpoint(sol, pm::PMs.GenericPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
-        PMs.add_setpoint(sol, pm, "branch", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "pf_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "qf_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "pf_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "qf_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+        PMs. add_setpoint!(sol, pm, "branch", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "pf_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "qf_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "pf_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "qf_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])], status_name="br_status")
 
-        PMs.add_setpoint(sol, pm, "branch", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "pt_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "qt_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "pt_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        PMs.add_setpoint(sol, pm, "branch", "qt_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+        PMs. add_setpoint!(sol, pm, "branch", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "pt_ut", :p_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "qt_ut", :q_ut; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "pt_lt", :p_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "qt_lt", :q_lt; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])], status_name="br_status")
 
     end
 end
@@ -504,10 +504,10 @@ end
 ""
 function add_branch_current_setpoint(sol, pm::PMs.GenericPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
-        PMs.add_setpoint(sol, pm, "branch", "cm", :cm; scale = (x,item,i) -> sqrt(x))
-        PMs.add_setpoint(sol, pm, "branch", "cc", :cm)
-        PMs.add_setpoint(sol, pm, "branch", "ccr", :ccmr)
-        PMs.add_setpoint(sol, pm, "branch", "cci", :ccmi)
+        PMs. add_setpoint!(sol, pm, "branch", "cm", :cm; scale = (x,item,i) -> sqrt(x), status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "cc", :cm, status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "ccr", :ccmr, status_name="br_status")
+        PMs. add_setpoint!(sol, pm, "branch", "cci", :ccmi, status_name="br_status")
     end
 end
 

--- a/src/form/bf_mx.jl
+++ b/src/form/bf_mx.jl
@@ -170,14 +170,14 @@ function variable_tp_branch_series_current_prod_hermitian(pm::_PMs.GenericPowerM
 
     for c in 1:n_diag_el
         if bounded
-            _PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
+            _PMs.var(pm, nw, c)[:ccm] = JuMP.@variable(pm.model,
             [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
             lower_bound = 0,
             upper_bound = (cmax[l][c])^2,
             start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c) #TODO shouldn't this be squared?
             )
         else
-            _PMs.var(pm, nw, c)[:cm] = JuMP.@variable(pm.model,
+            _PMs.var(pm, nw, c)[:ccm] = JuMP.@variable(pm.model,
             [l in _PMs.ids(pm, nw, :branch)], base_name="$(nw)_$(c)_cm",
             lower_bound = 0,
             start = _PMs.comp_start_value(_PMs.ref(pm, nw, :branch, l), "i_start", c)
@@ -218,7 +218,7 @@ function variable_tp_branch_series_current_prod_hermitian(pm::_PMs.GenericPowerM
     ccm_re_dict = Dict{Int64, Any}()
     ccm_im_dict = Dict{Int64, Any}()
     for i in _PMs.ids(pm, nw, :branch)
-        ccm =  [_PMs.var(pm, nw, h, :cm,  i) for h in 1:n_diag_el]
+        ccm =  [_PMs.var(pm, nw, h, :ccm,  i) for h in 1:n_diag_el]
         ccmr = [_PMs.var(pm, nw, h, :ccmr, i) for h in 1:n_lower_triangle_el]
         ccmi = [_PMs.var(pm, nw, h, :ccmi, i) for h in 1:n_lower_triangle_el]
 
@@ -504,8 +504,8 @@ end
 ""
 function add_branch_current_setpoint!(sol, pm::_PMs.GenericPowerModel)
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "branch_flows") && pm.setting["output"]["branch_flows"] == true
-        _PMs.add_setpoint!(sol, pm, "branch", "cm", :cm; scale = (x,item,i) -> sqrt(x), status_name="br_status")
-        _PMs.add_setpoint!(sol, pm, "branch", "cc", :cm, status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "ccm", :ccm; scale = (x,item,i) -> sqrt(x), status_name="br_status")
+        _PMs.add_setpoint!(sol, pm, "branch", "cc", :ccm, status_name="br_status")
         _PMs.add_setpoint!(sol, pm, "branch", "ccr", :ccmr, status_name="br_status")
         _PMs.add_setpoint!(sol, pm, "branch", "cci", :ccmi, status_name="br_status")
     end

--- a/src/form/bf_mx_sdp.jl
+++ b/src/form/bf_mx_sdp.jl
@@ -1,15 +1,15 @@
 """
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr) where T <: SDPUBFForm
-    p_fr = PMs.var(pm, n, :P_mx)[f_idx]
-    q_fr = PMs.var(pm, n, :Q_mx)[f_idx]
+function constraint_tp_model_current(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr) where T <: SDPUBFForm
+    p_fr = _PMs.var(pm, n, :P_mx)[f_idx]
+    q_fr = _PMs.var(pm, n, :Q_mx)[f_idx]
 
-    w_fr_re = PMs.var(pm, n, :W_re)[f_bus]
-    w_fr_im = PMs.var(pm, n, :W_im)[f_bus]
+    w_fr_re = _PMs.var(pm, n, :W_re)[f_bus]
+    w_fr_im = _PMs.var(pm, n, :W_im)[f_bus]
 
-    ccm_re =  PMs.var(pm, n, :CC_re)[i]
-    ccm_im =  PMs.var(pm, n, :CC_im)[i]
+    ccm_re =  _PMs.var(pm, n, :CC_re)[i]
+    ccm_im =  _PMs.var(pm, n, :CC_im)[i]
 
     p_s_fr = p_fr - (w_fr_re*(g_sh_fr)' + w_fr_im*(b_sh_fr)')
     q_s_fr = q_fr - (w_fr_im*(g_sh_fr)' - w_fr_re*(b_sh_fr)')

--- a/src/form/bf_mx_soc.jl
+++ b/src/form/bf_mx_soc.jl
@@ -2,15 +2,15 @@
 """
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr) where T <: SOCUBFForm
-    p_fr = PMs.var(pm, n, :P_mx)[f_idx]
-    q_fr = PMs.var(pm, n, :Q_mx)[f_idx]
+function constraint_tp_model_current(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr) where T <: SOCUBFForm
+    p_fr = _PMs.var(pm, n, :P_mx)[f_idx]
+    q_fr = _PMs.var(pm, n, :Q_mx)[f_idx]
 
-    w_fr_re = PMs.var(pm, n, :W_re)[f_bus]
-    w_fr_im = PMs.var(pm, n, :W_im)[f_bus]
+    w_fr_re = _PMs.var(pm, n, :W_re)[f_bus]
+    w_fr_im = _PMs.var(pm, n, :W_im)[f_bus]
 
-    ccm_re =  PMs.var(pm, n, :CC_re)[i]
-    ccm_im =  PMs.var(pm, n, :CC_im)[i]
+    ccm_re =  _PMs.var(pm, n, :CC_re)[i]
+    ccm_im =  _PMs.var(pm, n, :CC_im)[i]
 
     p_s_fr = p_fr - g_sh_fr*w_fr_re
     q_s_fr = q_fr + b_sh_fr*w_fr_re
@@ -30,7 +30,7 @@ function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}, n::Int, i, f
     # code below useful for debugging: valid inequality equired to make the SOC-NLP formulation more accurate
     # (l,i,j) = f_idx
     # t_idx = (l,j,i)
-    # p_to = PMs.var(pm, n, :P_mx)[t_idx]
+    # p_to = _PMs.var(pm, n, :P_mx)[t_idx]
     # total losses are positive when g_fr, g_to and r are positive
     # not guaranteed for individual phases though when matrix obtained through Kron's reduction
     # JuMP.@constraint(pm.model, tr(p_fr) + tr(p_to) >= 0)
@@ -40,15 +40,15 @@ end
 """
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
-function constraint_tp_branch_current(pm::PMs.GenericPowerModel{T}, n::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr) where T <: SOCConicUBFForm
-    p_fr = PMs.var(pm, n, :P_mx)[f_idx]
-    q_fr = PMs.var(pm, n, :Q_mx)[f_idx]
+function constraint_tp_model_current(pm::_PMs.GenericPowerModel{T}, n::Int, i, f_bus, f_idx, g_sh_fr, b_sh_fr) where T <: SOCConicUBFForm
+    p_fr = _PMs.var(pm, n, :P_mx)[f_idx]
+    q_fr = _PMs.var(pm, n, :Q_mx)[f_idx]
 
-    w_fr_re = PMs.var(pm, n, :W_re)[f_bus]
-    w_fr_im = PMs.var(pm, n, :W_im)[f_bus]
+    w_fr_re = _PMs.var(pm, n, :W_re)[f_bus]
+    w_fr_im = _PMs.var(pm, n, :W_im)[f_bus]
 
-    ccm_re =  PMs.var(pm, n, :CC_re)[i]
-    ccm_im =  PMs.var(pm, n, :CC_im)[i]
+    ccm_re =  _PMs.var(pm, n, :CC_re)[i]
+    ccm_im =  _PMs.var(pm, n, :CC_im)[i]
 
     p_s_fr = p_fr - g_sh_fr*w_fr_re
     q_s_fr = q_fr + b_sh_fr*w_fr_re

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -4,7 +4,7 @@
 ######## AbstractDCPForm Models (has va but assumes vm is 1.0) ########
 
 "nothing to do, these models do not have complex voltage constraints"
-function constraint_tp_voltage(pm::PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: PMs.AbstractDCPForm
+function constraint_tp_model_voltage(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: _PMs.AbstractDCPForm
 end
 
 
@@ -13,24 +13,24 @@ end
 ######## Lossless Models ########
 
 "Create variables for the active power flowing into all transformer windings."
-function variable_tp_trans_active_flow(pm::PMs.GenericPowerModel{T}; nw::Int=pm.cnw, bounded=true) where T <: PMs.DCPlosslessForm
-    for cnd in PMs.conductor_ids(pm)
-        pt = PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
-            [(l,i,j) in PMs.ref(pm, nw, :arcs_from_trans)],
+function variable_tp_trans_active_flow(pm::_PMs.GenericPowerModel{T}; nw::Int=pm.cnw, bounded=true) where T <: _PMs.DCPlosslessForm
+    for cnd in _PMs.conductor_ids(pm)
+        pt = _PMs.var(pm, nw, cnd)[:pt] = JuMP.@variable(pm.model,
+            [(l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)],
             base_name="$(nw)_$(cnd)_p_trans",
             start=0
         )
         if bounded
-            for arc in PMs.ref(pm, nw, :arcs_from_trans)
+            for arc in _PMs.ref(pm, nw, :arcs_from_trans)
                 tr_id = arc[1]
-                flow_lb  = -PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
-                flow_ub  =  PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_lb  = -_PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
+                flow_ub  =  _PMs.ref(pm, nw, :trans, tr_id, "rate_a")[cnd]
                 JuMP.set_lower_bound(pt[arc], flow_lb)
                 JuMP.set_upper_bound(pt[arc], flow_ub)
             end
         end
 
-        for (l,branch) in PMs.ref(pm, nw, :branch)
+        for (l,branch) in _PMs.ref(pm, nw, :branch)
             if haskey(branch, "pf_start")
                 f_idx = (l, branch["f_bus"], branch["t_bus"])
                 JuMP.set_value(p[f_idx], branch["pf_start"])
@@ -38,18 +38,18 @@ function variable_tp_trans_active_flow(pm::PMs.GenericPowerModel{T}; nw::Int=pm.
         end
 
         # this explicit type erasure is necessary
-        p_expr = Dict{Any,Any}( ((l,i,j), pt[(l,i,j)]) for (l,i,j) in PMs.ref(pm, nw, :arcs_from_trans) )
-        p_expr = merge(p_expr, Dict( ((l,j,i), -1.0*pt[(l,i,j)]) for (l,i,j) in PMs.ref(pm, nw, :arcs_from_trans)))
-        PMs.var(pm, nw, cnd)[:pt] = p_expr
+        p_expr = Dict{Any,Any}( ((l,i,j), pt[(l,i,j)]) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans) )
+        p_expr = merge(p_expr, Dict( ((l,j,i), -1.0*pt[(l,i,j)]) for (l,i,j) in _PMs.ref(pm, nw, :arcs_from_trans)))
+        _PMs.var(pm, nw, cnd)[:pt] = p_expr
     end
 end
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_tp_yt_to(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.DCPlosslessForm
+function constraint_tp_ohms_yt_to(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: _PMs.DCPlosslessForm
 end
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_tp_yt_to_on_off(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.DCPlosslessForm
+function constraint_tp_ohms_yt_to_on_off(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: _PMs.DCPlosslessForm
 end
 
 
@@ -64,25 +64,25 @@ Creates Ohms constraints (yt post fix indicates that Y and T values are in recta
 p[f_idx] == -b*(t[f_bus] - t[t_bus])
 ```
 """
-function constraint_ohms_tp_yt_from(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractDCPForm
-    p_fr  = PMs.var(pm, n, c,  :p, f_idx)
-    va_fr = [PMs.var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
-    va_to = [PMs.var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
+function constraint_tp_ohms_yt_from(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: _PMs.AbstractDCPForm
+    p_fr  = _PMs.var(pm, n, c,  :p, f_idx)
+    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
+    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
 
-    JuMP.@constraint(pm.model, p_fr == -sum(b[c,d]*(va_fr[c] - va_to[d]) for d in PMs.conductor_ids(pm)))
+    JuMP.@constraint(pm.model, p_fr == -sum(b[c,d]*(va_fr[c] - va_to[d]) for d in _PMs.conductor_ids(pm)))
     # omit reactive constraint
 end
 
 
 "`-b*(t[f_bus] - t[t_bus] + vad_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + vad_max*(1-branch_z[i]))`"
-function constraint_ohms_tp_yt_from_on_off(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractDCPForm
-    p_fr  = PMs.var(pm, n, c,  :p, f_idx)
-    va_fr = [PMs.var(pm, n, d, :va, f_bus) for d in PMs.conductor_ids(pm)]
-    va_to = [PMs.var(pm, n, d, :va, t_bus) for d in PMs.conductor_ids(pm)]
-    z = [PMs.var(pm, n, d, :branch_z, i) for d in PMs.conductor_ids(pm)]
+function constraint_tp_ohms_yt_from_on_off(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: _PMs.AbstractDCPForm
+    p_fr  = _PMs.var(pm, n, c,  :p, f_idx)
+    va_fr = [_PMs.var(pm, n, d, :va, f_bus) for d in _PMs.conductor_ids(pm)]
+    va_to = [_PMs.var(pm, n, d, :va, t_bus) for d in _PMs.conductor_ids(pm)]
+    z = [_PMs.var(pm, n, d, :branch_z, i) for d in _PMs.conductor_ids(pm)]
 
-    JuMP.@constraint(pm.model, p_fr <= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_max[d]*(1-z[d])) for d in PMs.conductor_ids(pm)) )
-    JuMP.@constraint(pm.model, p_fr >= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_min[d]*(1-z[d])) for d in PMs.conductor_ids(pm)) )
+    JuMP.@constraint(pm.model, p_fr <= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_max[d]*(1-z[d])) for d in _PMs.conductor_ids(pm)) )
+    JuMP.@constraint(pm.model, p_fr >= sum(-b[c,d]*(va_fr[d] - va_to[d] + vad_min[d]*(1-z[d])) for d in _PMs.conductor_ids(pm)) )
 end
 
 
@@ -90,22 +90,22 @@ end
 ### Network Flow Approximation ###
 
 "nothing to do, no voltage angle variables"
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: PMs.NFAForm
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: _PMs.NFAForm
 end
 
 "nothing to do, no voltage angle variables"
-function constraint_ohms_tp_yt_from(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.NFAForm
+function constraint_tp_ohms_yt_from(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: _PMs.NFAForm
 end
 
 "nothing to do, this model is symmetric"
-function constraint_ohms_tp_yt_to(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.NFAForm
+function constraint_tp_ohms_yt_to(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: _PMs.NFAForm
 end
 
 "nothing to do, no voltage variables"
-function constraint_tp_trans_voltage(pm::PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to) where T <: PMs.NFAForm
+function constraint_tp_trans_voltage(pm::_PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, tm::_PMs.MultiConductorVector, Tv_fr, Tv_im, Cv_to) where T <: _PMs.NFAForm
 end
 
 "nothing to do, this model is symmetric"
-function constraint_tp_trans_flow(pm::PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to) where T <: PMs.NFAForm
+function constraint_tp_trans_flow(pm::_PMs.GenericPowerModel{T}, nw::Int, i::Int, f_bus::Int, t_bus::Int, f_idx, t_idx, tm::_PMs.MultiConductorVector, Ti_fr, Ti_im, Cv_to) where T <: _PMs.NFAForm
 end
 

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -2,16 +2,16 @@
 
 
 ""
-function constraint_kcl_shunt_slack(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractWForms
-    w    = PMs.var(pm, n, c, :w, i)
-    p_slack = PMs.var(pm, n, c, :p_slack, i)
-    q_slack = PMs.var(pm, n, c, :q_slack, i)
-    pg   = PMs.var(pm, n, c, :pg)
-    qg   = PMs.var(pm, n, c, :qg)
-    p    = PMs.var(pm, n, c, :p)
-    q    = PMs.var(pm, n, c, :q)
-    p_dc = PMs.var(pm, n, c, :p_dc)
-    q_dc = PMs.var(pm, n, c, :q_dc)
+function constraint_tp_power_balance_shunt_slack(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractWForms
+    w    = _PMs.var(pm, n, c, :w, i)
+    p_slack = _PMs.var(pm, n, c, :p_slack, i)
+    q_slack = _PMs.var(pm, n, c, :q_slack, i)
+    pg   = _PMs.var(pm, n, c, :pg)
+    qg   = _PMs.var(pm, n, c, :qg)
+    p    = _PMs.var(pm, n, c, :p)
+    q    = _PMs.var(pm, n, c, :q)
+    p_dc = _PMs.var(pm, n, c, :p_dc)
+    q_dc = _PMs.var(pm, n, c, :q_dc)
 
     JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w + p_slack)
     JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w + q_slack)
@@ -22,58 +22,58 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_tp_yt_from(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: PMs.AbstractWRForms
-    p_fr = PMs.var(pm, n, c, :p, f_idx)
-    q_fr = PMs.var(pm, n, c, :q, f_idx)
-    w    = PMs.var(pm, n, :w)
-    wr   = PMs.var(pm, n, :wr)
-    wi   = PMs.var(pm, n, :wi)
+function constraint_tp_ohms_yt_from(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm) where T <: _PMs.AbstractWRForms
+    p_fr = _PMs.var(pm, n, c, :p, f_idx)
+    q_fr = _PMs.var(pm, n, c, :q, f_idx)
+    w    = _PMs.var(pm, n, :w)
+    wr   = _PMs.var(pm, n, :wr)
+    wi   = _PMs.var(pm, n, :wi)
 
     JuMP.@constraint(pm.model, p_fr ==  ( g_fr[c]+g[c,c]) * w[(f_bus, c)] +
                                 sum( g[c,d] * wr[(f_bus, f_bus, c, d)] +
-                                     b[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                     b[c,d] * wi[(f_bus, f_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) +
                                 sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                    -b[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                    -b[c,d] * wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
     JuMP.@constraint(pm.model, q_fr == -( b_fr[c]+b[c,c]) * w[(f_bus, c)] -
                                 sum( b[c,d] * wr[(f_bus, f_bus, c, d)] -
-                                     g[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                     g[c,d] * wi[(f_bus, f_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) -
                                 sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                     g[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                     g[c,d] * wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
 end
 
 
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_tp_yt_to(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: PMs.AbstractWRForms
-    q_to = PMs.var(pm, n, c, :q, t_idx)
-    p_to = PMs.var(pm, n, c, :p, t_idx)
-    w    = PMs.var(pm, n, :w)
-    wr   = PMs.var(pm, n, :wr)
-    wi   = PMs.var(pm, n, :wi)
+function constraint_tp_ohms_yt_to(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm) where T <: _PMs.AbstractWRForms
+    q_to = _PMs.var(pm, n, c, :q, t_idx)
+    p_to = _PMs.var(pm, n, c, :p, t_idx)
+    w    = _PMs.var(pm, n, :w)
+    wr   = _PMs.var(pm, n, :wr)
+    wi   = _PMs.var(pm, n, :wi)
 
     JuMP.@constraint(pm.model, p_to ==  ( g_to[c]+g[c,c]) * w[(t_bus, c)] +
                                 sum( g[c,d] * wr[(t_bus, t_bus, c, d)] +
-                                     b[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                     b[c,d] *-wi[(t_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) +
                                 sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                    -b[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                    -b[c,d] *-wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
     JuMP.@constraint(pm.model, q_to == -( b_to[c]+b[c,c]) * w[(t_bus, c)] -
                                 sum( b[c,d] * wr[(t_bus, t_bus, c, d)] -
-                                     g[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                     g[c,d] *-wi[(t_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) -
                                 sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                     g[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                     g[c,d] *-wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
 end
 
 
 "do nothing, no way to represent this in these variables"
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: PMs.AbstractWForms
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: _PMs.AbstractWForms
 end
 
 
 "Creates phase angle constraints at reference buses"
-function constraint_tp_theta_ref(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: PMs.AbstractPForms
-    va = PMs.var(pm, n, c, :va, d)
-    nconductors = length(PMs.conductor_ids(pm))
+function constraint_tp_theta_ref(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, d) where T <: _PMs.AbstractPForms
+    va = _PMs.var(pm, n, c, :va, d)
+    nconductors = length(_PMs.conductor_ids(pm))
 
     JuMP.@constraint(pm.model, va == _wrap_to_pi(2 * pi / nconductors * (1-c)))
 end
@@ -84,10 +84,10 @@ For a variable tap transformer, fix the tap variables which are fixed. For
 example, an OLTC where the third phase is fixed, will have tap variables for
 all phases, but the third tap variable should be fixed.
 """
-function constraint_tp_oltc_tap_fix(pm::PMs.GenericPowerModel, i::Int, fixed::PMs.MultiConductorVector, tm::PMs.MultiConductorVector; nw=pm.cnw)
+function constraint_tp_oltc_tap_fix(pm::_PMs.GenericPowerModel, i::Int, fixed::_PMs.MultiConductorVector, tm::_PMs.MultiConductorVector; nw=pm.cnw)
     for (c,fixed) in enumerate(fixed)
         if fixed
-            JuMP.@constraint(pm.model, PMs.var(pm, nw, c, :tap)[i]==tm[c])
+            JuMP.@constraint(pm.model, _PMs.var(pm, nw, c, :tap)[i]==tm[c])
         end
     end
 end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -2,18 +2,18 @@
 
 
 ""
-function constraint_tp_voltage(pm::PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: PMs.AbstractWRForm
-    w  = PMs.var(pm, n,  :w)
-    wr = PMs.var(pm, n, :wr)
-    wi = PMs.var(pm, n, :wi)
+function constraint_tp_model_voltage(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int) where T <: _PMs.AbstractWRForm
+    w  = _PMs.var(pm, n,  :w)
+    wr = _PMs.var(pm, n, :wr)
+    wi = _PMs.var(pm, n, :wi)
 
-    for d in c:length(PMs.conductor_ids(pm))
-        for (i,j) in PMs.ids(pm, n, :buspairs)
+    for d in c:length(_PMs.conductor_ids(pm))
+        for (i,j) in _PMs.ids(pm, n, :buspairs)
             InfrastructureModels.relaxation_complex_product(pm.model, w[(i,d)], w[(j,c)], wr[(i,j,c,d)], wi[(i,j,c,d)])
         end
 
         if d != c
-            for i in PMs.ids(pm, n, :bus)
+            for i in _PMs.ids(pm, n, :bus)
                 InfrastructureModels.relaxation_complex_product(pm.model, w[(i,d)], w[(i,c)], wr[(i,i,c,d)], wi[(i,i,c,d)])
             end
         end
@@ -29,23 +29,23 @@ p[f_idx] ==        g/tm*w_fr[i] + (-g*tr+b*ti)/tm*(wr[i]) + (-b*tr-g*ti)/tm*(wi[
 q[f_idx] == -(b+c/2)/tm*w_fr[i] - (-b*tr-g*ti)/tm*(wr[i]) + (-g*tr+b*ti)/tm*(wi[i])
 ```
 """
-function constraint_ohms_tp_yt_from_on_off(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractWRForm
-    p_fr = PMs.var(pm, n, c, :p, f_idx)
-    q_fr = PMs.var(pm, n, c, :q, f_idx)
-    w    = PMs.var(pm, n, :w)
-    wr   = PMs.var(pm, n, :wr)
-    wi   = PMs.var(pm, n, :wi)
+function constraint_tp_ohms_yt_from_on_off(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max) where T <: _PMs.AbstractWRForm
+    p_fr = _PMs.var(pm, n, c, :p, f_idx)
+    q_fr = _PMs.var(pm, n, c, :q, f_idx)
+    w    = _PMs.var(pm, n, :w)
+    wr   = _PMs.var(pm, n, :wr)
+    wi   = _PMs.var(pm, n, :wi)
 
     JuMP.@constraint(pm.model, p_fr ==  ( g_fr[c]+g[c,c]) * w[(f_bus, c)] +
                                 sum( g[c,d] * wr[(f_bus, f_bus, c, d)] +
-                                     b[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                     b[c,d] * wi[(f_bus, f_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) +
                                 sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                    -b[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                    -b[c,d] * wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
     JuMP.@constraint(pm.model, q_fr == -( b_fr[c]+b[c,c]) * w[(f_bus, c)] -
                                 sum( b[c,d] * wr[(f_bus, f_bus, c, d)] -
-                                     g[c,d] * wi[(f_bus, f_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                     g[c,d] * wi[(f_bus, f_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) -
                                 sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                     g[c,d] * wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                     g[c,d] * wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
 end
 
 """
@@ -56,36 +56,36 @@ p[t_idx] ==        g*w_to[i] + (-g*tr-b*ti)/tm*(wr[i]) + (-b*tr+g*ti)/tm*(-wi[i]
 q[t_idx] == -(b+c/2)*w_to[i] - (-b*tr+g*ti)/tm*(wr[i]) + (-g*tr-b*ti)/tm*(-wi[i])
 ```
 """
-function constraint_ohms_tp_yt_to_on_off(pm::PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: PMs.AbstractWRForm
-    p_to = PMs.var(pm, n, c, :p, t_idx)
-    q_to = PMs.var(pm, n, c, :q, t_idx)
-    w    = PMs.var(pm, n, :w)
-    wr   = PMs.var(pm, n, :wr)
-    wi   = PMs.var(pm, n, :wi)
+function constraint_tp_ohms_yt_to_on_off(pm::_PMs.GenericPowerModel{T}, n::Int, c::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max) where T <: _PMs.AbstractWRForm
+    p_to = _PMs.var(pm, n, c, :p, t_idx)
+    q_to = _PMs.var(pm, n, c, :q, t_idx)
+    w    = _PMs.var(pm, n, :w)
+    wr   = _PMs.var(pm, n, :wr)
+    wi   = _PMs.var(pm, n, :wi)
 
     JuMP.@constraint(pm.model, p_to ==  ( g_to[c]+g[c,c]) * w[(t_bus, c)] +
                                 sum( g[c,d] * wr[(t_bus, t_bus, c, d)] +
-                                     b[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) +
+                                     b[c,d] *-wi[(t_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) +
                                 sum(-g[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                    -b[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                    -b[c,d] *-wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
     JuMP.@constraint(pm.model, q_to == -( b_to[c]+b[c,c]) * w[(t_bus, c)] -
                                 sum( b[c,d] * wr[(t_bus, t_bus, c, d)] -
-                                     g[c,d] *-wi[(t_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm) if d != c) -
+                                     g[c,d] *-wi[(t_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm) if d != c) -
                                 sum(-b[c,d] * wr[(f_bus, t_bus, c, d)] +
-                                     g[c,d] *-wi[(f_bus, t_bus, c, d)] for d in PMs.conductor_ids(pm)) )
+                                     g[c,d] *-wi[(f_bus, t_bus, c, d)] for d in _PMs.conductor_ids(pm)) )
 end
 
 
-function constraint_kcl_shunt_trans(pm::PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: PMs.AbstractWRForm
-    w    = PMs.var(pm, nw, c, :w, i)
-    pg   = PMs.var(pm, nw, c, :pg)
-    qg   = PMs.var(pm, nw, c, :qg)
-    p    = PMs.var(pm, nw, c, :p)
-    q    = PMs.var(pm, nw, c, :q)
-    p_dc = PMs.var(pm, nw, c, :p_dc)
-    q_dc = PMs.var(pm, nw, c, :q_dc)
-    p_trans = PMs.var(pm, nw, c, :pt)
-    q_trans = PMs.var(pm,  nw, c, :qt)
+function constraint_tp_power_balance_shunt_trans(pm::_PMs.GenericPowerModel{T}, nw::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_trans, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs) where T <: _PMs.AbstractWRForm
+    w    = _PMs.var(pm, nw, c, :w, i)
+    pg   = _PMs.var(pm, nw, c, :pg)
+    qg   = _PMs.var(pm, nw, c, :qg)
+    p    = _PMs.var(pm, nw, c, :p)
+    q    = _PMs.var(pm, nw, c, :q)
+    p_dc = _PMs.var(pm, nw, c, :p_dc)
+    q_dc = _PMs.var(pm, nw, c, :q_dc)
+    p_trans = _PMs.var(pm, nw, c, :pt)
+    q_trans = _PMs.var(pm,  nw, c, :qt)
 
     JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_trans[a_trans] for a_trans in bus_arcs_trans) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w)
     JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_trans[a_trans] for a_trans in bus_arcs_trans) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w)

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -7,12 +7,12 @@ function parse_file(io::IO; import_all::Bool=false, vmin::Float64=0.9, vmax::Flo
     if filetype == "m"
         tppm_data = ThreePhasePowerModels.parse_matlab(io)
     elseif filetype == "dss"
-        Memento.warn(LOGGER, "Not all OpenDSS features are supported, currently only minimal support for lines, loads, generators, and capacitors as shunts. Transformers and reactors as transformer branches are included, but value translation is not fully supported.")
+        Memento.warn(_LOGGER, "Not all OpenDSS features are supported, currently only minimal support for lines, loads, generators, and capacitors as shunts. Transformers and reactors as transformer branches are included, but value translation is not fully supported.")
         tppm_data = ThreePhasePowerModels.parse_opendss(io; import_all=import_all, vmin=vmin, vmax=vmax)
     elseif filetype == "json"
         tppm_data = PowerModels.parse_json(io; validate=false)
     else
-        Memento.error(LOGGER, "only .m and .dss files are supported")
+        Memento.error(_LOGGER, "only .m and .dss files are supported")
     end
 
     correct_network_data!(tppm_data)

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -32,19 +32,19 @@ end
 
 ""
 function correct_network_data!(data::Dict{String,Any})
-    PMs.make_per_unit!(data)
+    _PMs.make_per_unit!(data)
 
-    PMs.check_connectivity(data)
-    PMs.correct_transformer_parameters!(data)
-    PMs.correct_voltage_angle_differences!(data)
-    PMs.correct_thermal_limits!(data)
-    PMs.correct_branch_directions!(data)
-    PMs.check_branch_loops(data)
-    PMs.correct_bus_types!(data)
-    PMs.correct_dcline_limits!(data)
-    # PMs.check_voltage_setpoints(data)
-    PMs.correct_cost_functions!(data)
-    PMs.standardize_cost_terms!(data)
+    _PMs.check_connectivity(data)
+    _PMs.correct_transformer_parameters!(data)
+    _PMs.correct_voltage_angle_differences!(data)
+    _PMs.correct_thermal_limits!(data)
+    _PMs.correct_branch_directions!(data)
+    _PMs.check_branch_loops(data)
+    _PMs.correct_bus_types!(data)
+    _PMs.correct_dcline_limits!(data)
+    # _PMs.check_voltage_setpoints(data)
+    _PMs.correct_cost_functions!(data)
+    _PMs.standardize_cost_terms!(data)
 end
 
 function _wrap_to_180(degrees)

--- a/src/io/dss_structs.jl
+++ b/src/io/dss_structs.jl
@@ -188,7 +188,7 @@ function _createLine(bus1, bus2, name::AbstractString; kwargs...)
     len = get(kwargs, :length, 1.0) * to_meters[units]
 
     if haskey(kwargs, :rg)
-        Memento.warn(LOGGER, "Rg,Xg are not fully supported")
+        Memento.warn(_LOGGER, "Rg,Xg are not fully supported")
     end
 
     rmatrix .+= rg * (freq/basefreq - 1.0)
@@ -943,7 +943,7 @@ function _createPVSystem(bus1, name::AbstractString; kwargs...)
     end
 
     if haskey(kwargs, :like)
-        Memento.warn(LOGGER, "\"like\" keyword on pvsystem $name is not supported.")
+        Memento.warn(_LOGGER, "\"like\" keyword on pvsystem $name is not supported.")
     end
 
     pvsystem = Dict{String,Any}("name" => name,

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -205,7 +205,7 @@ function parse_matlab_string(data_string::String)
     if haskey(matlab_data, "tppmc.gencost")
         gencost = []
         for (i, gencost_row) in enumerate(matlab_data["tppmc.gencost"])
-            gencost_data = PMs.mp_cost_data(gencost_row)
+            gencost_data = PMs._mp_cost_data(gencost_row)
             gencost_data["index"] = i
             push!(gencost, gencost_data)
         end
@@ -284,10 +284,10 @@ function matlab_to_tppm(ml_data::Dict{String,Any})
     ml2pm_gen(ml_data)
     ml2pm_branch(ml_data)
 
-    PMs.merge_bus_name_data(ml_data)
-    PMs.merge_generator_cost_data(ml_data)
+    PMs._merge_bus_name_data!(ml_data)
+    PMs._merge_generator_cost_data!(ml_data)
 
-    PMs.merge_generic_data(ml_data)
+    PMs._merge_generic_data!(ml_data)
 
     InfrastructureModels.arrays_to_dicts!(ml_data)
 

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -102,7 +102,7 @@ function parse_matlab_string(data_string::String)
     if func_name != nothing
         case["name"] = func_name
     else
-        Memento.warn(LOGGER, string("no case name found in matlab file.  The file seems to be missing \"function mpc = ...\""))
+        Memento.warn(_LOGGER, string("no case name found in matlab file.  The file seems to be missing \"function mpc = ...\""))
         case["name"] = "no_name_found"
     end
 
@@ -110,7 +110,7 @@ function parse_matlab_string(data_string::String)
     if haskey(matlab_data, "tppmc.version")
         case["source_version"] = string(VersionNumber(matlab_data["tppmc.version"]))
     else
-        Memento.warn(LOGGER, "No version number found, file may not be compatible with parser.")
+        Memento.warn(_LOGGER, "No version number found, file may not be compatible with parser.")
         case["source_version"] = string(v"0")
 
     end
@@ -118,14 +118,14 @@ function parse_matlab_string(data_string::String)
     if haskey(matlab_data, "tppmc.baseMVA")
         case["baseMVA"] = matlab_data["tppmc.baseMVA"]
     else
-        Memento.warn(LOGGER, string("no baseMVA found in matlab file.  The file seems to be missing \"tppmc.baseMVA = ...\""))
+        Memento.warn(_LOGGER, string("no baseMVA found in matlab file.  The file seems to be missing \"tppmc.baseMVA = ...\""))
         case["baseMVA"] = 1.0
     end
 
     if haskey(matlab_data, "tppmc.baseKV")
         case["baseKV"] = matlab_data["tppmc.baseKV"]
     else
-        Memento.warn(LOGGER, string("no baseKV found in matlab file.  The file seems to be missing \"tppmc.baseKV = ...\""))
+        Memento.warn(_LOGGER, string("no baseKV found in matlab file.  The file seems to be missing \"tppmc.baseKV = ...\""))
         case["baseKV"] = 1.0
     end
 
@@ -232,10 +232,10 @@ function parse_matlab_string(data_string::String)
                     push!(tbl, row_data)
                 end
                 case[case_name] = tbl
-                Memento.info(LOGGER, "extending matlab format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
+                Memento.info(_LOGGER, "extending matlab format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
             else
                 case[case_name] = value
-                Memento.info(LOGGER, "extending matlab format with constant data: $(case_name)")
+                Memento.info(_LOGGER, "extending matlab format with constant data: $(case_name)")
             end
         end
     end
@@ -253,7 +253,7 @@ function _translate_version!(ml_data::Dict{String,Any})
     if ml_data["source_version"] == _current_version
         return ml_data
     else
-        Memento.warn(LOGGER, "matlab source data has unrecognized version $(ml_data["source_version"]), cannot translate to version $_current_version, parse may be invalid")
+        Memento.warn(_LOGGER, "matlab source data has unrecognized version $(ml_data["source_version"]), cannot translate to version $_current_version, parse may be invalid")
         return ml_data
     end
 end

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -205,7 +205,7 @@ function parse_matlab_string(data_string::String)
     if haskey(matlab_data, "tppmc.gencost")
         gencost = []
         for (i, gencost_row) in enumerate(matlab_data["tppmc.gencost"])
-            gencost_data = PMs._mp_cost_data(gencost_row)
+            gencost_data = _PMs._mp_cost_data(gencost_row)
             gencost_data["index"] = i
             push!(gencost, gencost_data)
         end
@@ -227,7 +227,7 @@ function parse_matlab_string(data_string::String)
                 end
                 tbl = []
                 for (i, row) in enumerate(matlab_data[k])
-                    row_data = PMs.row_to_dict(row, column_names)
+                    row_data = _PMs.row_to_dict(row, column_names)
                     row_data["index"] = i
                     push!(tbl, row_data)
                 end
@@ -284,10 +284,10 @@ function matlab_to_tppm(ml_data::Dict{String,Any})
     ml2pm_gen(ml_data)
     ml2pm_branch(ml_data)
 
-    PMs._merge_bus_name_data!(ml_data)
-    PMs._merge_generator_cost_data!(ml_data)
+    _PMs._merge_bus_name_data!(ml_data)
+    _PMs._merge_generator_cost_data!(ml_data)
 
-    PMs._merge_generic_data!(ml_data)
+    _PMs._merge_generic_data!(ml_data)
 
     InfrastructureModels.arrays_to_dicts!(ml_data)
 
@@ -346,12 +346,12 @@ end
 "convert raw branch data into arrays"
 function ml2pm_branch(data::Dict{String,Any})
     for branch in data["branch"]
-        branch["rate_a"] = PMs.MultiConductorVector(branch["rate_a"], 3)
-        branch["rate_b"] = PMs.MultiConductorVector(branch["rate_b"], 3)
-        branch["rate_c"] = PMs.MultiConductorVector(branch["rate_c"], 3)
+        branch["rate_a"] = _PMs.MultiConductorVector(branch["rate_a"], 3)
+        branch["rate_b"] = _PMs.MultiConductorVector(branch["rate_b"], 3)
+        branch["rate_c"] = _PMs.MultiConductorVector(branch["rate_c"], 3)
 
-        branch["angmin"] = PMs.MultiConductorVector(branch["angmin"], 3)
-        branch["angmax"] = PMs.MultiConductorVector(branch["angmax"], 3)
+        branch["angmin"] = _PMs.MultiConductorVector(branch["angmin"], 3)
+        branch["angmax"] = _PMs.MultiConductorVector(branch["angmax"], 3)
 
         _set_default(branch, "g_fr_1", 0.0)
         _set_default(branch, "g_fr_2", 0.0)
@@ -364,24 +364,24 @@ function ml2pm_branch(data::Dict{String,Any})
         _make_mpv!(branch, "g_fr", ["g_fr_1", "g_fr_2", "g_fr_3"])
         _make_mpv!(branch, "g_to", ["g_to_1", "g_to_2", "g_to_3"])
 
-        branch["b_fr"] = PMs.MultiConductorVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
-        branch["b_to"] = PMs.MultiConductorVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
+        branch["b_fr"] = _PMs.MultiConductorVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
+        branch["b_to"] = _PMs.MultiConductorVector([branch["b_1"], branch["b_2"], branch["b_3"]]) / 2.0
 
         delete!(branch, "b_1")
         delete!(branch, "b_2")
         delete!(branch, "b_3")
 
-        branch["tap"] = PMs.MultiConductorVector(1.0, 3)
-        branch["shift"] = PMs.MultiConductorVector(0.0, 3)
+        branch["tap"] = _PMs.MultiConductorVector(1.0, 3)
+        branch["shift"] = _PMs.MultiConductorVector(0.0, 3)
         branch["transformer"] = false
 
-        branch["br_r"] = PMs.MultiConductorMatrix([
+        branch["br_r"] = _PMs.MultiConductorMatrix([
             branch["r_11"]     branch["r_12"]/2.0 branch["r_13"]/2.0;
             branch["r_12"]/2.0 branch["r_22"]     branch["r_23"]/2.0;
             branch["r_13"]/2.0 branch["r_23"]/2.0 branch["r_33"];
         ])
 
-        branch["br_x"] = PMs.MultiConductorMatrix([
+        branch["br_x"] = _PMs.MultiConductorMatrix([
             branch["x_11"]     branch["x_12"]/2.0 branch["x_13"]/2.0;
             branch["x_12"]/2.0 branch["x_22"]     branch["x_23"]/2.0;
             branch["x_13"]/2.0 branch["x_23"]/2.0 branch["x_33"];
@@ -398,7 +398,7 @@ end
 "collects several from_keys in an array and sets it to the to_key, removes from_keys"
 function _make_mpv!(data::Dict{String,Any}, to_key::String, from_keys::Array{String,1})
     @assert !(haskey(data, to_key))
-    data[to_key] = PMs.MultiConductorVector([data[k] for k in from_keys])
+    data[to_key] = _PMs.MultiConductorVector([data[k] for k in from_keys])
     for k in from_keys
         delete!(data, k)
     end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -212,7 +212,7 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             loadDict["index"] = length(tppm_data["load"]) + 1
 
             used = ["phases", "bus1", "name"]
-            PMs.import_remaining!(loadDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(loadDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["load"], loadDict)
         end
@@ -261,7 +261,7 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             shuntDict["source_id"] = "capacitor.$(defaults["name"])"
 
             used = ["bus1", "phases", "name"]
-            PMs.import_remaining!(shuntDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(shuntDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["shunt"], shuntDict)
         end
@@ -296,7 +296,7 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
                 shuntDict["source_id"] = "reactor.$(defaults["name"])"
 
                 used = ["bus1", "phases", "name"]
-                PMs.import_remaining!(shuntDict, defaults, import_all; exclude=used)
+                PMs._import_remaining!(shuntDict, defaults, import_all; exclude=used)
 
                 push!(tppm_data["shunt"], shuntDict)
             end
@@ -350,7 +350,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
     genDict["source_id"] = "vsource.$(defaults["name"])"
 
     used = ["name", "phases", "bus1"]
-    PMs.import_remaining!(genDict, defaults, import_all; exclude=used)
+    PMs._import_remaining!(genDict, defaults, import_all; exclude=used)
 
     push!(tppm_data["gen"], genDict)
 
@@ -417,7 +417,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             genDict["source_id"] = "generator.$(defaults["name"])"
 
             used = ["name", "phases", "bus1"]
-            PMs.import_remaining!(genDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(genDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["gen"], genDict)
         end
@@ -465,7 +465,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             pvDict["source_id"] = "pvsystem.$(defaults["name"])"
 
             used = ["name", "phases", "bus1"]
-            PMs.import_remaining!(pvDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(pvDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["gen"], pvDict)
         end
@@ -578,7 +578,7 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             branchDict["source_id"] = "line.$(defaults["name"])"
 
             used = ["name", "bus1", "bus2", "rmatrix", "xmatrix"]
-            PMs.import_remaining!(branchDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(branchDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["branch"], branchDict)
         end
@@ -858,7 +858,7 @@ function dss2tppm_reactor!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
                 reactDict["source_id"] = "reactor.$(defaults["name"])"
 
                 used = []
-                PMs.import_remaining!(reactDict, defaults, import_all; exclude=used)
+                PMs._import_remaining!(reactDict, defaults, import_all; exclude=used)
 
                 push!(tppm_data["branch"], reactDict)
             end
@@ -898,7 +898,7 @@ function dss2tppm_pvsystem!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             pvsystemDict["source_id"] = "pvsystem.$(defaults["name"])"
 
             used = ["phases", "bus1", "name"]
-            PMs.import_remaining!(pvsystemDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(pvsystemDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["pvsystem"], pvsystemDict)
         end
@@ -942,7 +942,7 @@ function dss2tppm_storage!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             storageDict["source_id"] = "storage.$(defaults["name"])"
 
             used = ["phases", "bus1", "name"]
-            PMs.import_remaining!(storageDict, defaults, import_all; exclude=used)
+            PMs._import_remaining!(storageDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["storage"], storageDict)
         end

--- a/src/io/opendss.jl
+++ b/src/io/opendss.jl
@@ -33,18 +33,18 @@ end
 function _create_starbus(tppm_data::Dict, transformer::Dict)::Dict
     starbus = Dict{String,Any}()
 
-    base = convert(Int, 10^ceil(log10(abs(PMs.find_max_bus_id(tppm_data)))))
+    base = convert(Int, 10^ceil(log10(abs(_PMs.find_max_bus_id(tppm_data)))))
     name, nodes = parse_busname(transformer["buses"][1])
     nconductors = tppm_data["conductors"]
     starbus_id = _find_bus(name, tppm_data) + base
 
     starbus["bus_i"] = starbus_id
     starbus["base_kv"] = 1.0
-    starbus["vmin"] = PMs.MultiConductorVector(parse_array(0.9, nodes, nconductors, 0.9))
-    starbus["vmax"] = PMs.MultiConductorVector(parse_array(1.1, nodes, nconductors, 1.1))
+    starbus["vmin"] = _PMs.MultiConductorVector(parse_array(0.9, nodes, nconductors, 0.9))
+    starbus["vmax"] = _PMs.MultiConductorVector(parse_array(1.1, nodes, nconductors, 1.1))
     starbus["name"] = "$(transformer["name"]) starbus"
-    starbus["vm"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors))
-    starbus["va"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+    starbus["vm"] = _PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors))
+    starbus["va"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
     starbus["bus_type"] = 1
     starbus["index"] = starbus_id
 
@@ -126,11 +126,11 @@ function dss2tppm_bus!(tppm_data::Dict, dss_data::Dict, import_all::Bool=false, 
 
         busDict["bus_type"] = bus == sourcebus ? 3 : 1
 
-        busDict["vm"] = PMs.MultiConductorVector(parse_array(vm, nodes, nconductors))
-        busDict["va"] = PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nconductors*(i-1))+ph1_ang for i in 1:nconductors], nodes, nconductors))
+        busDict["vm"] = _PMs.MultiConductorVector(parse_array(vm, nodes, nconductors))
+        busDict["va"] = _PMs.MultiConductorVector(parse_array([rad2deg(2*pi/nconductors*(i-1))+ph1_ang for i in 1:nconductors], nodes, nconductors))
 
-        busDict["vmin"] = PMs.MultiConductorVector(parse_array(vmi, nodes, nconductors, vmi))
-        busDict["vmax"] = PMs.MultiConductorVector(parse_array(vma, nodes, nconductors, vma))
+        busDict["vmin"] = _PMs.MultiConductorVector(parse_array(vmi, nodes, nconductors, vmi))
+        busDict["vmax"] = _PMs.MultiConductorVector(parse_array(vma, nodes, nconductors, vma))
 
         busDict["base_kv"] = tppm_data["basekv"]
 
@@ -202,8 +202,8 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             loadDict["name"] = defaults["name"]
             loadDict["load_bus"] = _find_bus(name, tppm_data)
-            loadDict["pd"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nconductors))
-            loadDict["qd"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nconductors))
+            loadDict["pd"] = _PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nconductors))
+            loadDict["qd"] = _PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nconductors))
             loadDict["status"] = convert(Int, defaults["enabled"])
 
             loadDict["active_phases"] = [n for n in 1:nconductors if nodes[n] > 0]
@@ -212,7 +212,7 @@ function dss2tppm_load!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             loadDict["index"] = length(tppm_data["load"]) + 1
 
             used = ["phases", "bus1", "name"]
-            PMs._import_remaining!(loadDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(loadDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["load"], loadDict)
         end
@@ -252,8 +252,8 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             shuntDict["shunt_bus"] = _find_bus(name, tppm_data)
             shuntDict["name"] = defaults["name"]
-            shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:
-            shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nconductors))
+            shuntDict["gs"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:
+            shuntDict["bs"] = _PMs.MultiConductorVector(parse_array(Gcap, nodes, nconductors))
             shuntDict["status"] = convert(Int, defaults["enabled"])
             shuntDict["index"] = length(tppm_data["shunt"]) + 1
 
@@ -261,7 +261,7 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             shuntDict["source_id"] = "capacitor.$(defaults["name"])"
 
             used = ["bus1", "phases", "name"]
-            PMs._import_remaining!(shuntDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(shuntDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["shunt"], shuntDict)
         end
@@ -287,8 +287,8 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
                 shuntDict["shunt_bus"] = _find_bus(name, tppm_data)
                 shuntDict["name"] = defaults["name"]
-                shuntDict["gs"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:
-                shuntDict["bs"] = PMs.MultiConductorVector(parse_array(Gcap, nodes, nconductors))
+                shuntDict["gs"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))  # TODO:
+                shuntDict["bs"] = _PMs.MultiConductorVector(parse_array(Gcap, nodes, nconductors))
                 shuntDict["status"] = convert(Int, defaults["enabled"])
                 shuntDict["index"] = length(tppm_data["shunt"]) + 1
 
@@ -296,7 +296,7 @@ function dss2tppm_shunt!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
                 shuntDict["source_id"] = "reactor.$(defaults["name"])"
 
                 used = ["bus1", "phases", "name"]
-                PMs._import_remaining!(shuntDict, defaults, import_all; exclude=used)
+                _PMs._import_remaining!(shuntDict, defaults, import_all; exclude=used)
 
                 push!(tppm_data["shunt"], shuntDict)
             end
@@ -329,14 +329,14 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
     genDict["gen_status"] = convert(Int, defaults["enabled"])
 
     # TODO: populate with VSOURCE properties
-    genDict["pg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nconductors))
-    genDict["qg"] = PMs.MultiConductorVector(parse_array( 0.0, nodes, nconductors))
+    genDict["pg"] = _PMs.MultiConductorVector(parse_array( 0.0, nodes, nconductors))
+    genDict["qg"] = _PMs.MultiConductorVector(parse_array( 0.0, nodes, nconductors))
 
-    genDict["qmin"] = PMs.MultiConductorVector(parse_array(-NaN, nodes, nconductors))
-    genDict["qmax"] = PMs.MultiConductorVector(parse_array( NaN, nodes, nconductors))
+    genDict["qmin"] = _PMs.MultiConductorVector(parse_array(-NaN, nodes, nconductors))
+    genDict["qmax"] = _PMs.MultiConductorVector(parse_array( NaN, nodes, nconductors))
 
-    genDict["pmin"] = PMs.MultiConductorVector(parse_array(-NaN, nodes, nconductors))
-    genDict["pmax"] = PMs.MultiConductorVector(parse_array( NaN, nodes, nconductors))
+    genDict["pmin"] = _PMs.MultiConductorVector(parse_array(-NaN, nodes, nconductors))
+    genDict["pmax"] = _PMs.MultiConductorVector(parse_array( NaN, nodes, nconductors))
 
     genDict["model"] = 2
     genDict["startup"] = 0.0
@@ -350,7 +350,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
     genDict["source_id"] = "vsource.$(defaults["name"])"
 
     used = ["name", "phases", "bus1"]
-    PMs._import_remaining!(genDict, defaults, import_all; exclude=used)
+    _PMs._import_remaining!(genDict, defaults, import_all; exclude=used)
 
     push!(tppm_data["gen"], genDict)
 
@@ -371,14 +371,14 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             genDict["gen_bus"] = _find_bus(name, tppm_data)
             genDict["name"] = defaults["name"]
             genDict["gen_status"] = convert(Int, defaults["enabled"])
-            genDict["pg"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / (1e3 * nconductors), nodes, nconductors))
-            genDict["qg"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / (1e3 * nconductors), nodes, nconductors))
-            genDict["vg"] = PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nconductors))
+            genDict["pg"] = _PMs.MultiConductorVector(parse_array(defaults["kw"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["qg"] = _PMs.MultiConductorVector(parse_array(defaults["kvar"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["vg"] = _PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nconductors))
 
-            genDict["qmin"] = PMs.MultiConductorVector(parse_array(defaults["minkvar"] / (1e3 * nconductors), nodes, nconductors))
-            genDict["qmax"] = PMs.MultiConductorVector(parse_array(defaults["maxkvar"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["qmin"] = _PMs.MultiConductorVector(parse_array(defaults["minkvar"] / (1e3 * nconductors), nodes, nconductors))
+            genDict["qmax"] = _PMs.MultiConductorVector(parse_array(defaults["maxkvar"] / (1e3 * nconductors), nodes, nconductors))
 
-            genDict["apf"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            genDict["apf"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             genDict["pmax"] = genDict["pg"]  # Assumes generator is at rated power
             genDict["pmin"] = 0.0 * genDict["pg"]  # 0% of pmax
@@ -394,7 +394,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             # and they are not supported in OpenDSS
             genDict["ramp_agc"] = genDict["pmax"]
 
-            genDict["ramp_q"] = PMs.MultiConductorVector(parse_array(max.(abs.(genDict["qmin"].values), abs.(genDict["qmax"].values)), nodes, nconductors))
+            genDict["ramp_q"] = _PMs.MultiConductorVector(parse_array(max.(abs.(genDict["qmin"].values), abs.(genDict["qmax"].values)), nodes, nconductors))
             genDict["ramp_10"] = genDict["pmax"]
             genDict["ramp_30"] = genDict["pmax"]
 
@@ -417,7 +417,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             genDict["source_id"] = "generator.$(defaults["name"])"
 
             used = ["name", "phases", "bus1"]
-            PMs._import_remaining!(genDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(genDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["gen"], genDict)
         end
@@ -441,15 +441,15 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             pvDict["name"] = defaults["name"]
             pvDict["gen_bus"] = _find_bus(name, tppm_data)
 
-            pvDict["pg"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
-            pvDict["qg"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
-            pvDict["vg"] = PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nconductors))
+            pvDict["pg"] = _PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["qg"] = _PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["vg"] = _PMs.MultiConductorVector(parse_array(defaults["kv"] / tppm_data["basekv"], nodes, nconductors))
 
-            pvDict["pmin"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
-            pvDict["pmax"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["pmin"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            pvDict["pmax"] = _PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
 
-            pvDict["qmin"] = -PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
-            pvDict["qmax"] =  PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["qmin"] = -_PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
+            pvDict["qmax"] =  _PMs.MultiConductorVector(parse_array(defaults["kva"] / (1e3 * nconductors), nodes, nconductors))
 
             pvDict["gen_status"] = convert(Int, defaults["enabled"])
 
@@ -465,7 +465,7 @@ function dss2tppm_gen!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             pvDict["source_id"] = "pvsystem.$(defaults["name"])"
 
             used = ["name", "phases", "bus1"]
-            PMs._import_remaining!(pvDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(pvDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["gen"], pvDict)
         end
@@ -542,31 +542,31 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             # is fixed at 1. So implicitly, we later on state that the voltage base
             # is actually in LN. We compensate here for that.
 
-            branchDict["br_r"] = PMs.MultiConductorMatrix(rmatrix * defaults["length"] / Zbase)
-            branchDict["br_x"] = PMs.MultiConductorMatrix(xmatrix * defaults["length"] / Zbase)
+            branchDict["br_r"] = _PMs.MultiConductorMatrix(rmatrix * defaults["length"] / Zbase)
+            branchDict["br_x"] = _PMs.MultiConductorMatrix(xmatrix * defaults["length"] / Zbase)
 
             # CHECK: Do we need to reformulate to use a matrix instead of a vector for g, b?
-            branchDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
-            branchDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            branchDict["g_fr"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            branchDict["g_to"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             if !isdiag(cmatrix)
                 Memento.info(_LOGGER, "Only diagonal elements of cmatrix are used to obtain branch values `b_fr/to`")
             end
-            branchDict["b_fr"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["basefreq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
-            branchDict["b_to"] = PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["basefreq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
+            branchDict["b_fr"] = _PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["basefreq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
+            branchDict["b_to"] = _PMs.MultiConductorVector(diag(Zbase * (2.0 * pi * defaults["basefreq"] * cmatrix * defaults["length"] / 1e9) / 2.0))
 
             # TODO: pick a better value for emergamps
-            branchDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nconductors))
-            branchDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
-            branchDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
+            branchDict["rate_a"] = _PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nconductors))
+            branchDict["rate_b"] = _PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
+            branchDict["rate_c"] = _PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
 
-            branchDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors, 1.0))
-            branchDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+            branchDict["tap"] = _PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors, 1.0))
+            branchDict["shift"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
             branchDict["br_status"] = convert(Int, defaults["enabled"])
 
-            branchDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
-            branchDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
+            branchDict["angmin"] = _PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
+            branchDict["angmax"] = _PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
 
             branchDict["transformer"] = false
             branchDict["switch"] = defaults["switch"]
@@ -578,7 +578,7 @@ function dss2tppm_branch!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             branchDict["source_id"] = "line.$(defaults["name"])"
 
             used = ["name", "bus1", "bus2", "rmatrix", "xmatrix"]
-            PMs._import_remaining!(branchDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(branchDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["branch"], branchDict)
         end
@@ -632,9 +632,9 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
             # voltage and power ratings
             #transDict["vnom_kv"] = defaults["kvs"]
             #transDict["snom_kva"] = defaults["kvas"]
-            transDict["rate_a"] = [PMs.MultiConductorVector(ones(nconductors))*defaults["normhkva"] for i in 1:nrw]
-            transDict["rate_b"] = [PMs.MultiConductorVector(ones(nconductors))*defaults["normhkva"] for i in 1:nrw]
-            transDict["rate_c"] = [PMs.MultiConductorVector(ones(nconductors))*defaults["emerghkva"] for i  in 1:nrw]
+            transDict["rate_a"] = [_PMs.MultiConductorVector(ones(nconductors))*defaults["normhkva"] for i in 1:nrw]
+            transDict["rate_b"] = [_PMs.MultiConductorVector(ones(nconductors))*defaults["normhkva"] for i in 1:nrw]
+            transDict["rate_c"] = [_PMs.MultiConductorVector(ones(nconductors))*defaults["emerghkva"] for i  in 1:nrw]
             # convert to 1 MVA base
             transDict["rate_a"] *= 1E-3
             transDict["rate_b"] *= 1E-3
@@ -685,11 +685,11 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
             end
 
             # tap properties
-            transDict["tm"] = [PMs.MultiConductorVector(ones(Float64,3))*defaults["taps"][i] for i in 1:nrw]
-            transDict["tm_min"] = [PMs.MultiConductorVector(ones(Float64,3))*defaults["mintap"] for i in 1:nrw]
-            transDict["tm_max"] = [PMs.MultiConductorVector(ones(Float64,3))*defaults["maxtap"] for i in 1:nrw]
-            transDict["tm_step"] = [PMs.MultiConductorVector(ones(Int,3))*defaults["numtaps"] for i in 1:nrw]
-            transDict["fixed"] = [PMs.MultiConductorVector(ones(Bool,3)) for i in 1:nrw]
+            transDict["tm"] = [_PMs.MultiConductorVector(ones(Float64,3))*defaults["taps"][i] for i in 1:nrw]
+            transDict["tm_min"] = [_PMs.MultiConductorVector(ones(Float64,3))*defaults["mintap"] for i in 1:nrw]
+            transDict["tm_max"] = [_PMs.MultiConductorVector(ones(Float64,3))*defaults["maxtap"] for i in 1:nrw]
+            transDict["tm_step"] = [_PMs.MultiConductorVector(ones(Int,3))*defaults["numtaps"] for i in 1:nrw]
+            transDict["fixed"] = [_PMs.MultiConductorVector(ones(Bool,3)) for i in 1:nrw]
 
             # loss model (converted to SI units, referred to secondary)
             function zpn_to_abc(z, p, n; atol=1E-13)
@@ -701,9 +701,9 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
             end
             pos_to_abc(p) = zpn_to_abc(p, p, p)
             zbase = 1^2/(defaults["kvas"][1]/1E3)
-            transDict["rs"] = Array{PMs.MultiConductorMatrix{Float64}, 1}(undef, nrw)
-            transDict["gsh"] = Array{PMs.MultiConductorMatrix{Float64}, 1}(undef, nrw)
-            transDict["bsh"] = Array{PMs.MultiConductorMatrix{Float64}, 1}(undef, nrw)
+            transDict["rs"] = Array{_PMs.MultiConductorMatrix{Float64}, 1}(undef, nrw)
+            transDict["gsh"] = Array{_PMs.MultiConductorMatrix{Float64}, 1}(undef, nrw)
+            transDict["bsh"] = Array{_PMs.MultiConductorMatrix{Float64}, 1}(undef, nrw)
             # deal with dual definition of rs in defaults dict
             # if non-zero, pick "%rs", else go for the per winding spec
             rs_alt = [defaults["%r$suffix"] for suffix in prop_suffix_w]
@@ -723,19 +723,19 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
                 # neutral impedance is ignored for now; all transformers are
                 # grounded (that is, those with a wye and zig-zag winding).
                 Memento.warn(_LOGGER, "The neutral impedance, (rg and xg properties), is ignored; the neutral (for wye and zig-zag windings) is connected directly to the ground.")
-                transDict["rs"][w] = PMs.MultiConductorMatrix(real.(Zs_w))
+                transDict["rs"][w] = _PMs.MultiConductorMatrix(real.(Zs_w))
                 # shunt elements are added at second winding
                 if w==2
                     ysh_w_p = (defaults["%noloadloss"]-im*defaults["%imag"])/100/zbase
                     Ysh_w = pos_to_abc(ysh_w_p)
-                    transDict["gsh"][w] = PMs.MultiConductorMatrix(real.(Ysh_w))
-                    transDict["bsh"][w] = PMs.MultiConductorMatrix(imag.(Ysh_w))
+                    transDict["gsh"][w] = _PMs.MultiConductorMatrix(real.(Ysh_w))
+                    transDict["bsh"][w] = _PMs.MultiConductorMatrix(imag.(Ysh_w))
                 else
-                    transDict["gsh"][w] = PMs.MultiConductorMatrix(zeros(Float64, 3, 3))
-                    transDict["bsh"][w] = PMs.MultiConductorMatrix(zeros(Float64, 3, 3))
+                    transDict["gsh"][w] = _PMs.MultiConductorMatrix(zeros(Float64, 3, 3))
+                    transDict["bsh"][w] = _PMs.MultiConductorMatrix(zeros(Float64, 3, 3))
                 end
             end
-            transDict["xs"] = Dict{String, PMs.MultiConductorMatrix{Float64}}()
+            transDict["xs"] = Dict{String, _PMs.MultiConductorMatrix{Float64}}()
 
             Zsc = Dict{Tuple{Int,Int}, Complex}()
             if nrw==2
@@ -749,7 +749,7 @@ function dss2tppm_transformer!(tppm_data::Dict, dss_data::Dict, import_all::Bool
             Zbr = _sc2br_impedance(Zsc)
             for (k,zs_ij_p) in Zbr
                 Zs_ij = pos_to_abc(zs_ij_p)
-                transDict["xs"]["$(k[1])-$(k[2])"] = PMs.MultiConductorMatrix(imag.(Zs_ij))
+                transDict["xs"]["$(k[1])-$(k[2])"] = _PMs.MultiConductorMatrix(imag.(Zs_ij))
             end
 
             push!(tppm_data["trans_comp"], transDict)
@@ -829,25 +829,25 @@ function dss2tppm_reactor!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
                 reactDict["f_bus"] = _find_bus(f_bus, tppm_data)
                 reactDict["t_bus"] = _find_bus(t_bus, tppm_data)
 
-                reactDict["br_r"] = PMs.MultiConductorMatrix(parse_matrix(diagm(0 => fill(0.2, nconductors)), nodes, nconductors))
-                reactDict["br_x"] = PMs.MultiConductorMatrix(parse_matrix(zeros(nconductors, nconductors), nodes, nconductors))
+                reactDict["br_r"] = _PMs.MultiConductorMatrix(parse_matrix(diagm(0 => fill(0.2, nconductors)), nodes, nconductors))
+                reactDict["br_x"] = _PMs.MultiConductorMatrix(parse_matrix(zeros(nconductors, nconductors), nodes, nconductors))
 
-                reactDict["g_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
-                reactDict["g_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
-                reactDict["b_fr"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
-                reactDict["b_to"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["g_fr"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["g_to"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["b_fr"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["b_to"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
-                reactDict["rate_a"] = PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nconductors))
-                reactDict["rate_b"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
-                reactDict["rate_c"] = PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
+                reactDict["rate_a"] = _PMs.MultiConductorVector(parse_array(defaults["normamps"], nodes, nconductors))
+                reactDict["rate_b"] = _PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
+                reactDict["rate_c"] = _PMs.MultiConductorVector(parse_array(defaults["emergamps"], nodes, nconductors))
 
-                reactDict["tap"] = PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors, NaN))
-                reactDict["shift"] = PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
+                reactDict["tap"] = _PMs.MultiConductorVector(parse_array(1.0, nodes, nconductors, NaN))
+                reactDict["shift"] = _PMs.MultiConductorVector(parse_array(0.0, nodes, nconductors))
 
                 reactDict["br_status"] = convert(Int, defaults["enabled"])
 
-                reactDict["angmin"] = PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
-                reactDict["angmax"] = PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
+                reactDict["angmin"] = _PMs.MultiConductorVector(parse_array(-60.0, nodes, nconductors, -60.0))
+                reactDict["angmax"] = _PMs.MultiConductorVector(parse_array( 60.0, nodes, nconductors,  60.0))
 
                 reactDict["transformer"] = true
 
@@ -858,7 +858,7 @@ function dss2tppm_reactor!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
                 reactDict["source_id"] = "reactor.$(defaults["name"])"
 
                 used = []
-                PMs._import_remaining!(reactDict, defaults, import_all; exclude=used)
+                _PMs._import_remaining!(reactDict, defaults, import_all; exclude=used)
 
                 push!(tppm_data["branch"], reactDict)
             end
@@ -888,8 +888,8 @@ function dss2tppm_pvsystem!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
 
             pvsystemDict["name"] = defaults["name"]
             pvsystemDict["pv_bus"] = _find_bus(name, tppm_data)
-            pvsystemDict["p"] = PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nconductors))
-            pvsystemDict["q"] = PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nconductors))
+            pvsystemDict["p"] = _PMs.MultiConductorVector(parse_array(defaults["kw"] / 1e3, nodes, nconductors))
+            pvsystemDict["q"] = _PMs.MultiConductorVector(parse_array(defaults["kvar"] / 1e3, nodes, nconductors))
             pvsystemDict["status"] = convert(Int, defaults["enabled"])
 
             pvsystemDict["index"] = length(tppm_data["pvsystem"]) + 1
@@ -898,7 +898,7 @@ function dss2tppm_pvsystem!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             pvsystemDict["source_id"] = "pvsystem.$(defaults["name"])"
 
             used = ["phases", "bus1", "name"]
-            PMs._import_remaining!(pvsystemDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(pvsystemDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["pvsystem"], pvsystemDict)
         end
@@ -928,11 +928,11 @@ function dss2tppm_storage!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             storageDict["discharge_rating"] = defaults["%discharge"] * defaults["kwrated"] / 1e3 / 100.0
             storageDict["charge_efficiency"] = defaults["%effcharge"] / 100.0
             storageDict["discharge_efficiency"] = defaults["%effdischarge"] / 100.0
-            storageDict["thermal_rating"] = PMs.MultiConductorVector(parse_array(defaults["kva"] / 1e3, nodes, nconductors))
-            storageDict["qmin"] = PMs.MultiConductorVector(parse_array(-defaults["kvar"] / 1e3, nodes, nconductors))
-            storageDict["qmax"] = PMs.MultiConductorVector(parse_array( defaults["kvar"] / 1e3, nodes, nconductors))
-            storageDict["r"] = PMs.MultiConductorVector(parse_array(defaults["%r"] / 100.0, nodes, nconductors))
-            storageDict["x"] = PMs.MultiConductorVector(parse_array(defaults["%x"] / 100.0, nodes, nconductors))
+            storageDict["thermal_rating"] = _PMs.MultiConductorVector(parse_array(defaults["kva"] / 1e3, nodes, nconductors))
+            storageDict["qmin"] = _PMs.MultiConductorVector(parse_array(-defaults["kvar"] / 1e3, nodes, nconductors))
+            storageDict["qmax"] = _PMs.MultiConductorVector(parse_array( defaults["kvar"] / 1e3, nodes, nconductors))
+            storageDict["r"] = _PMs.MultiConductorVector(parse_array(defaults["%r"] / 100.0, nodes, nconductors))
+            storageDict["x"] = _PMs.MultiConductorVector(parse_array(defaults["%x"] / 100.0, nodes, nconductors))
             storageDict["standby_loss"] = defaults["%idlingkw"] * defaults["kwrated"] / 1e3
             storageDict["status"] = convert(Int, defaults["enabled"])
 
@@ -942,7 +942,7 @@ function dss2tppm_storage!(tppm_data::Dict, dss_data::Dict, import_all::Bool)
             storageDict["source_id"] = "storage.$(defaults["name"])"
 
             used = ["phases", "bus1", "name"]
-            PMs._import_remaining!(storageDict, defaults, import_all; exclude=used)
+            _PMs._import_remaining!(storageDict, defaults, import_all; exclude=used)
 
             push!(tppm_data["storage"], storageDict)
         end
@@ -979,10 +979,10 @@ function _adjust_sourcegen_bounds!(tppm_data)
 
     bound = sum(emergamps)
 
-    tppm_data["gen"]["1"]["pmin"] = PMs.MultiConductorVector(fill(-bound, size(tppm_data["gen"]["1"]["pmin"])))
-    tppm_data["gen"]["1"]["pmax"] = PMs.MultiConductorVector(fill( bound, size(tppm_data["gen"]["1"]["pmin"])))
-    tppm_data["gen"]["1"]["qmin"] = PMs.MultiConductorVector(fill(-bound, size(tppm_data["gen"]["1"]["pmin"])))
-    tppm_data["gen"]["1"]["qmax"] = PMs.MultiConductorVector(fill( bound, size(tppm_data["gen"]["1"]["pmin"])))
+    tppm_data["gen"]["1"]["pmin"] = _PMs.MultiConductorVector(fill(-bound, size(tppm_data["gen"]["1"]["pmin"])))
+    tppm_data["gen"]["1"]["pmax"] = _PMs.MultiConductorVector(fill( bound, size(tppm_data["gen"]["1"]["pmin"])))
+    tppm_data["gen"]["1"]["qmin"] = _PMs.MultiConductorVector(fill(-bound, size(tppm_data["gen"]["1"]["pmin"])))
+    tppm_data["gen"]["1"]["qmax"] = _PMs.MultiConductorVector(fill( bound, size(tppm_data["gen"]["1"]["pmin"])))
 end
 
 
@@ -1093,10 +1093,10 @@ function _create_vbus!(tppm_data; vmin=0, vmax=Inf, basekv=tppm_data["basekv"], 
     vbus["bus_i"] = vbus_id
     vbus["source_id"] = source_id
     ncnds = tppm_data["conductors"]
-    vbus["vm"] = PMs.MultiConductorVector(ones(Float64, ncnds))
-    vbus["va"] = PMs.MultiConductorVector(zeros(Float64, ncnds))
-    vbus["vmin"] = PMs.MultiConductorVector(ones(Float64, ncnds))*vmin
-    vbus["vmax"] = PMs.MultiConductorVector(ones(Float64, ncnds))*vmax
+    vbus["vm"] = _PMs.MultiConductorVector(ones(Float64, ncnds))
+    vbus["va"] = _PMs.MultiConductorVector(zeros(Float64, ncnds))
+    vbus["vmin"] = _PMs.MultiConductorVector(ones(Float64, ncnds))*vmin
+    vbus["vmax"] = _PMs.MultiConductorVector(ones(Float64, ncnds))*vmax
     vbus["base_kv"] = basekv
     return vbus
 end
@@ -1121,9 +1121,9 @@ function _create_vbranch!(tppm_data, f_bus::Int, t_bus::Int; name="", source_id=
     for k in [:br_r, :br_x, :g_fr, :g_to, :b_fr, :b_to]
         if !haskey(kwargs, k)
             if k in [:br_r, :br_x]
-                vbranch[string(k)] = PMs.MultiConductorMatrix(zeros(ncnd, ncnd))
+                vbranch[string(k)] = _PMs.MultiConductorMatrix(zeros(ncnd, ncnd))
             else
-                vbranch[string(k)] = PMs.MultiConductorVector(zeros(ncnd))
+                vbranch[string(k)] = _PMs.MultiConductorVector(zeros(ncnd))
             end
         else
             if k in [:br_r, :br_x]
@@ -1133,10 +1133,10 @@ function _create_vbranch!(tppm_data, f_bus::Int, t_bus::Int; name="", source_id=
             end
         end
     end
-    vbranch["angmin"] = -PMs.MultiConductorVector(ones(ncnd))*60
-    vbranch["angmax"] = PMs.MultiConductorVector(ones(ncnd))*60
-    vbranch["shift"] = PMs.MultiConductorVector(zeros(ncnd))
-    vbranch["tap"] = PMs.MultiConductorVector(ones(ncnd))
+    vbranch["angmin"] = -_PMs.MultiConductorVector(ones(ncnd))*60
+    vbranch["angmax"] = _PMs.MultiConductorVector(ones(ncnd))*60
+    vbranch["shift"] = _PMs.MultiConductorVector(zeros(ncnd))
+    vbranch["tap"] = _PMs.MultiConductorVector(ones(ncnd))
     vbranch["transformer"] = false
     vbranch["switch"] = false
     vbranch["br_status"] = 1
@@ -1202,8 +1202,8 @@ function _rm_redundant_pd_elements!(tppm_data; buses=keys(tppm_data["bus"]), bra
             end
             # move shunts to the bus that will be left
             if !haskey(shunts_g, kp_bus)
-                shunts_g[kp_bus] =  PMs.MultiConductorVector(zeros(3))
-                shunts_b[kp_bus] =  PMs.MultiConductorVector(zeros(3))
+                shunts_g[kp_bus] =  _PMs.MultiConductorVector(zeros(3))
+                shunts_b[kp_bus] =  _PMs.MultiConductorVector(zeros(3))
             end
             shunts_g[kp_bus] .+= br["g_fr"]
             shunts_g[kp_bus] .+= br["g_to"]
@@ -1271,7 +1271,7 @@ or XLT==0 or R[3]==0), then this bus might be removed by
 _rm_redundant_pd_elements!, in which case a new shunt should be inserted at the
 remaining bus of the removed branch.
 """
-function _add_shunt!(tppm_data, bus; gs=PMs.MultiConductorVector(zeros(3)), bs=PMs.MultiConductorVector(zeros(3)), vbase_kv=1, sbase_mva=1)
+function _add_shunt!(tppm_data, bus; gs=_PMs.MultiConductorVector(zeros(3)), bs=_PMs.MultiConductorVector(zeros(3)), vbase_kv=1, sbase_mva=1)
     # TODO check whether keys are consistent with the actual data model
     shunt_dict = Dict{String, Any}("status"=>1, "shunt_bus"=>bus)
     zbase  = vbase_kv^2/sbase_mva

--- a/src/prob/tp_debug.jl
+++ b/src/prob/tp_debug.jl
@@ -5,50 +5,50 @@ export run_tp_opf_pbs, run_tp_pf_pbs
 
 ""
 function run_tp_opf_pbs(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 
 ""
 function run_tp_opf_pbs(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 
 ""
-function post_tp_opf_pbs(pm::PMs.GenericPowerModel)
+function post_tp_opf_pbs(pm::_PMs.GenericPowerModel)
     variable_tp_voltage(pm)
     variable_tp_branch_flow(pm)
 
-    for c in PMs.conductor_ids(pm)
-        variable_bus_power_slack(pm, cnd=c)
-        PMs.variable_generation(pm, cnd=c)
-        PMs.variable_dcline_flow(pm, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        variable_tp_bus_power_slack(pm, cnd=c)
+        _PMs.variable_generation(pm, cnd=c)
+        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
-    constraint_tp_voltage(pm)
+    constraint_tp_model_voltage(pm)
 
-    for i in PMs.ids(pm, :ref_buses)
+    for i in _PMs.ids(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
     end
 
-    for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        constraint_kcl_shunt_slack(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
+        constraint_tp_power_balance_shunt_slack(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :branch), c in PMs.conductor_ids(pm)
-        constraint_ohms_tp_yt_from(pm, i, cnd=c)
-        constraint_ohms_tp_yt_to(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :branch), c in _PMs.conductor_ids(pm)
+        constraint_tp_ohms_yt_from(pm, i, cnd=c)
+        constraint_tp_ohms_yt_to(pm, i, cnd=c)
 
-        PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+        _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-        PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-        PMs.constraint_thermal_limit_to(pm, i, cnd=c)
+        _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+        _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :dcline), c in PMs.conductor_ids(pm)
-        PMs.constraint_dcline(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
     objective_min_bus_power_slack(pm)
@@ -58,69 +58,69 @@ end
 
 ""
 function run_tp_pf_pbs(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 
 ""
 function run_tp_pf_pbs(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 ""
-function post_tp_pf_pbs(pm::PMs.GenericPowerModel)
+function post_tp_pf_pbs(pm::_PMs.GenericPowerModel)
     variable_tp_voltage(pm, bounded=false)
     variable_tp_branch_flow(pm, bounded=false)
 
-    for c in PMs.conductor_ids(pm)
-        variable_bus_power_slack(pm, cnd=c)
-        PMs.variable_generation(pm, bounded=false, cnd=c)
-        PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        variable_tp_bus_power_slack(pm, cnd=c)
+        _PMs.variable_generation(pm, bounded=false, cnd=c)
+        _PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
-    constraint_tp_voltage(pm)
+    constraint_tp_model_voltage(pm)
 
-    for (i,bus) in PMs.ref(pm, :ref_buses)
+    for (i,bus) in _PMs.ref(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
-        for c in PMs.conductor_ids(pm)
+        for c in _PMs.conductor_ids(pm)
 
             @assert bus["bus_type"] == 3
-            PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
         end
     end
 
-    for (i,bus) in PMs.ref(pm, :bus), c in PMs.conductor_ids(pm)
-        constraint_kcl_shunt_slack(pm, i, cnd=c)
+    for (i,bus) in _PMs.ref(pm, :bus), c in _PMs.conductor_ids(pm)
+        constraint_tp_power_balance_shunt_slack(pm, i, cnd=c)
 
         # PV Bus Constraints
-        if length(PMs.ref(pm, :bus_gens, i)) > 0 && !(i in PMs.ids(pm,:ref_buses))
+        if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
             # this assumes inactive generators are filtered out of bus_gens
             @assert bus["bus_type"] == 2
 
-            PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-            for j in PMs.ref(pm, :bus_gens, i)
-                PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
+            for j in _PMs.ref(pm, :bus_gens, i)
+                _PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
             end
         end
     end
 
-    for i in PMs.ids(pm, :branch), c in PMs.conductor_ids(pm)
-        constraint_ohms_tp_yt_from(pm, i, cnd=c)
-        constraint_ohms_tp_yt_to(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :branch), c in _PMs.conductor_ids(pm)
+        constraint_tp_ohms_yt_from(pm, i, cnd=c)
+        constraint_tp_ohms_yt_to(pm, i, cnd=c)
     end
 
-    for (i,dcline) in PMs.ref(pm, :dcline), c in PMs.conductor_ids(pm)
-        PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
+    for (i,dcline) in _PMs.ref(pm, :dcline), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
 
-        f_bus = PMs.ref(pm, :bus)[dcline["f_bus"]]
+        f_bus = _PMs.ref(pm, :bus)[dcline["f_bus"]]
         if f_bus["bus_type"] == 1
-            PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
         end
 
-        t_bus = PMs.ref(pm, :bus)[dcline["t_bus"]]
+        t_bus = _PMs.ref(pm, :bus)[dcline["t_bus"]]
         if t_bus["bus_type"] == 1
-            PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
         end
     end
 
@@ -129,16 +129,16 @@ end
 
 
 ""
-function get_pbs_solution(pm::PMs.GenericPowerModel, sol::Dict{String,Any})
-    PMs. add_setpoint_bus_voltage!(sol, pm)
-    PMs.add_setpoint_generator_power!(sol, pm)
-    PMs.add_setpoint_branch_flow!(sol, pm)
+function get_pbs_solution(pm::_PMs.GenericPowerModel, sol::Dict{String,Any})
+    _PMs.add_setpoint_bus_voltage!(sol, pm)
+    _PMs.add_setpoint_generator_power!(sol, pm)
+    _PMs.add_setpoint_branch_flow!(sol, pm)
     add_bus_slack_setpoint(sol, pm)
 end
 
 
 ""
-function add_bus_slack_setpoint(sol, pm::PMs.GenericPowerModel)
-    PMs. add_setpoint!(sol, pm, "bus", "p_slack", :p_slack, status_name="bus_type", inactive_status_value=4)
-    PMs. add_setpoint!(sol, pm, "bus", "q_slack", :q_slack, status_name="bus_type", inactive_status_value=4)
+function add_bus_slack_setpoint(sol, pm::_PMs.GenericPowerModel)
+    _PMs.add_setpoint!(sol, pm, "bus", "p_slack", :p_slack, status_name="bus_type", inactive_status_value=4)
+    _PMs.add_setpoint!(sol, pm, "bus", "q_slack", :q_slack, status_name="bus_type", inactive_status_value=4)
 end

--- a/src/prob/tp_debug.jl
+++ b/src/prob/tp_debug.jl
@@ -5,14 +5,14 @@ export run_tp_opf_pbs, run_tp_pf_pbs
 
 ""
 function run_tp_opf_pbs(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 
 ""
 function run_tp_opf_pbs(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 
@@ -58,14 +58,14 @@ end
 
 ""
 function run_tp_pf_pbs(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 
 ""
 function run_tp_pf_pbs(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_pf_pbs; multiconductor=true, solution_builder = get_pbs_solution, kwargs...)
 end
 
 ""
@@ -130,15 +130,15 @@ end
 
 ""
 function get_pbs_solution(pm::PMs.GenericPowerModel, sol::Dict{String,Any})
-    PMs.add_bus_voltage_setpoint(sol, pm)
-    PMs.add_generator_power_setpoint(sol, pm)
-    PMs.add_branch_flow_setpoint(sol, pm)
+    PMs. add_setpoint_bus_voltage!(sol, pm)
+    PMs.add_setpoint_generator_power!(sol, pm)
+    PMs.add_setpoint_branch_flow!(sol, pm)
     add_bus_slack_setpoint(sol, pm)
 end
 
 
 ""
 function add_bus_slack_setpoint(sol, pm::PMs.GenericPowerModel)
-    PMs.add_setpoint(sol, pm, "bus", "p_slack", :p_slack)
-    PMs.add_setpoint(sol, pm, "bus", "q_slack", :q_slack)
+    PMs. add_setpoint!(sol, pm, "bus", "p_slack", :p_slack, status_name="bus_type", inactive_status_value=4)
+    PMs. add_setpoint!(sol, pm, "bus", "q_slack", :q_slack, status_name="bus_type", inactive_status_value=4)
 end

--- a/src/prob/tp_opf.jl
+++ b/src/prob/tp_opf.jl
@@ -2,65 +2,65 @@ export run_tp_opf, run_ac_tp_opf
 
 ""
 function run_ac_tp_opf(file, solver; kwargs...)
-    return run_tp_opf(file, PMs.ACPPowerModel, solver; multiconductor=true, kwargs...)
+    return run_tp_opf(file, _PMs.ACPPowerModel, solver; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
-function post_tp_opf(pm::PMs.GenericPowerModel)
+function post_tp_opf(pm::_PMs.GenericPowerModel)
     add_arcs_trans!(pm)
 
     variable_tp_voltage(pm)
     variable_tp_branch_flow(pm)
 
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_generation(pm, cnd=c)
-        PMs.variable_dcline_flow(pm, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_generation(pm, cnd=c)
+        _PMs.variable_dcline_flow(pm, cnd=c)
     end
     variable_tp_trans_flow(pm)
 
-    constraint_tp_voltage(pm)
+    constraint_tp_model_voltage(pm)
 
-    for i in PMs.ids(pm, :ref_buses)
+    for i in _PMs.ids(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
     end
 
-    for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        constraint_kcl_shunt_trans(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
+        constraint_tp_power_balance_shunt_trans(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :branch)
-        for c in PMs.conductor_ids(pm)
-            constraint_ohms_tp_yt_from(pm, i, cnd=c)
-            constraint_ohms_tp_yt_to(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :branch)
+        for c in _PMs.conductor_ids(pm)
+            constraint_tp_ohms_yt_from(pm, i, cnd=c)
+            constraint_tp_ohms_yt_to(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
     end
 
-    for i in PMs.ids(pm, :dcline), c in PMs.conductor_ids(pm)
-        PMs.constraint_dcline(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :trans)
         constraint_tp_trans(pm, i)
     end
 
-    PMs.objective_min_fuel_cost(pm)
+    _PMs.objective_min_fuel_cost(pm)
 end

--- a/src/prob/tp_opf.jl
+++ b/src/prob/tp_opf.jl
@@ -8,14 +8,14 @@ end
 
 ""
 function run_tp_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 

--- a/src/prob/tp_opf_bf.jl
+++ b/src/prob/tp_opf_bf.jl
@@ -2,56 +2,56 @@ export run_tp_opf_bf
 
 ""
 function run_tp_opf_bf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf_bf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
 
 
 ""
-function post_tp_opf_bf(pm::PMs.GenericPowerModel)
+function post_tp_opf_bf(pm::_PMs.GenericPowerModel)
     # Variables
     variable_tp_voltage(pm)
     variable_tp_branch_current(pm)
     variable_tp_branch_flow(pm)
 
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_generation(pm, cnd=c)
-        PMs.variable_dcline_flow(pm, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_generation(pm, cnd=c)
+        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
     # Constraints
-    constraint_tp_branch_current(pm)
+    constraint_tp_model_current(pm)
 
-    for i in PMs.ids(pm, :ref_buses)
+    for i in _PMs.ids(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
     end
 
-    for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        PMs. constraint_power_balance_shunt(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_power_balance_shunt(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :branch)
+    for i in _PMs.ids(pm, :branch)
         constraint_tp_flow_losses(pm, i)
 
-        constraint_tp_voltage_magnitude_difference(pm, i)
+        constraint_tp_model_voltage_magnitude_difference(pm, i)
 
-        for c in PMs.conductor_ids(pm)
-            PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+        for c in _PMs.conductor_ids(pm)
+            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
     end
 
-    for i in PMs.ids(pm, :dcline), c in PMs.conductor_ids(pm)
-        PMs.constraint_dcline(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    PMs.objective_min_fuel_cost(pm)
+    _PMs.objective_min_fuel_cost(pm)
 end

--- a/src/prob/tp_opf_bf.jl
+++ b/src/prob/tp_opf_bf.jl
@@ -2,14 +2,14 @@ export run_tp_opf_bf
 
 ""
 function run_tp_opf_bf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf_bf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
 
 
@@ -26,21 +26,20 @@ function post_tp_opf_bf(pm::PMs.GenericPowerModel)
     end
 
     # Constraints
+    constraint_tp_branch_current(pm)
+
     for i in PMs.ids(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
     end
 
     for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        PMs.constraint_kcl_shunt(pm, i, cnd=c)
+        PMs. constraint_power_balance_shunt(pm, i, cnd=c)
     end
 
     for i in PMs.ids(pm, :branch)
         constraint_tp_flow_losses(pm, i)
 
         constraint_tp_voltage_magnitude_difference(pm, i)
-
-        constraint_tp_branch_current(pm, i)
-
 
         for c in PMs.conductor_ids(pm)
             PMs.constraint_voltage_angle_difference(pm, i, cnd=c)

--- a/src/prob/tp_opf_oltc.jl
+++ b/src/prob/tp_opf_oltc.jl
@@ -8,14 +8,14 @@ end
 
 ""
 function run_tp_opf_oltc(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf_oltc(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 

--- a/src/prob/tp_opf_oltc.jl
+++ b/src/prob/tp_opf_oltc.jl
@@ -2,66 +2,66 @@ export run_tp_opf_oltc, run_ac_tp_opf_oltc
 
 ""
 function run_ac_tp_opf_oltc(file, solver; kwargs...)
-    return run_tp_opf(file, PMs.ACPPowerModel, solver; multiconductor=true, kwargs...)
+    return run_tp_opf(file, _PMs.ACPPowerModel, solver; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf_oltc(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_opf_oltc(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_opf; multiconductor=true, kwargs...)
 end
 
 
 ""
-function post_tp_opf_oltc(pm::PMs.GenericPowerModel)
+function post_tp_opf_oltc(pm::_PMs.GenericPowerModel)
     add_arcs_trans!(pm)
 
     variable_tp_voltage(pm)
     variable_tp_branch_flow(pm)
 
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_generation(pm, cnd=c)
-        PMs.variable_dcline_flow(pm, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_generation(pm, cnd=c)
+        _PMs.variable_dcline_flow(pm, cnd=c)
     end
     variable_tp_trans_flow(pm)
     variable_tp_oltc_tap(pm)
 
-    constraint_tp_voltage(pm)
+    constraint_tp_model_voltage(pm)
 
-    for i in PMs.ids(pm, :ref_buses)
+    for i in _PMs.ids(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
     end
 
-    for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        constraint_kcl_shunt_trans(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
+        constraint_tp_power_balance_shunt_trans(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :branch)
-        for c in PMs.conductor_ids(pm)
-            constraint_ohms_tp_yt_from(pm, i, cnd=c)
-            constraint_ohms_tp_yt_to(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :branch)
+        for c in _PMs.conductor_ids(pm)
+            constraint_tp_ohms_yt_from(pm, i, cnd=c)
+            constraint_tp_ohms_yt_to(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
     end
 
-    for i in PMs.ids(pm, :dcline), c in PMs.conductor_ids(pm)
-        PMs.constraint_dcline(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :trans)
         constraint_tp_oltc(pm, i)
     end
 
-    PMs.objective_min_fuel_cost(pm)
+    _PMs.objective_min_fuel_cost(pm)
 end

--- a/src/prob/tp_ots.jl
+++ b/src/prob/tp_ots.jl
@@ -2,14 +2,14 @@ export run_tp_ots
 
 ""
 function run_tp_ots(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
 end
 
 
 ""
 function run_tp_ots(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
 end
 
 
@@ -31,7 +31,7 @@ function post_tp_ots(pm::PMs.GenericPowerModel)
         end
 
         for i in PMs.ids(pm, :bus)
-            PMs.constraint_kcl_shunt(pm, i, cnd=c)
+            PMs. constraint_power_balance_shunt(pm, i, cnd=c)
         end
 
         for i in PMs.ids(pm, :branch)

--- a/src/prob/tp_ots.jl
+++ b/src/prob/tp_ots.jl
@@ -2,52 +2,52 @@ export run_tp_ots
 
 ""
 function run_tp_ots(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=_PMs.get_ots_solution, kwargs...)
 end
 
 
 ""
 function run_tp_ots(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=PMs.get_ots_solution, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_ots; multiconductor=true, solution_builder=_PMs.get_ots_solution, kwargs...)
 end
 
 
 ""
-function post_tp_ots(pm::PMs.GenericPowerModel)
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_branch_indicator(pm, cnd=c)
-        PMs.variable_voltage_on_off(pm, cnd=c)
-        PMs.variable_generation(pm, cnd=c)
-        PMs.variable_branch_flow(pm, cnd=c)
-        PMs.variable_dcline_flow(pm, cnd=c)
+function post_tp_ots(pm::_PMs.GenericPowerModel)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_branch_indicator(pm, cnd=c)
+        _PMs.variable_voltage_on_off(pm, cnd=c)
+        _PMs.variable_generation(pm, cnd=c)
+        _PMs.variable_branch_flow(pm, cnd=c)
+        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
-    for c in PMs.conductor_ids(pm)
-        PMs.constraint_voltage_on_off(pm, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.constraint_voltage_on_off(pm, cnd=c)
 
-        for i in PMs.ids(pm, :ref_buses)
+        for i in _PMs.ids(pm, :ref_buses)
             constraint_tp_theta_ref(pm, i, cnd=c)
         end
 
-        for i in PMs.ids(pm, :bus)
-            PMs. constraint_power_balance_shunt(pm, i, cnd=c)
+        for i in _PMs.ids(pm, :bus)
+            _PMs.constraint_power_balance_shunt(pm, i, cnd=c)
         end
 
-        for i in PMs.ids(pm, :branch)
-            constraint_ohms_tp_yt_from_on_off(pm, i, cnd=c)
-            constraint_ohms_tp_yt_to_on_off(pm, i, cnd=c)
+        for i in _PMs.ids(pm, :branch)
+            constraint_tp_ohms_yt_from_on_off(pm, i, cnd=c)
+            constraint_tp_ohms_yt_to_on_off(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference_on_off(pm, i, cnd=c)
+            _PMs.constraint_voltage_angle_difference_on_off(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from_on_off(pm, i, cnd=c)
-            PMs.constraint_thermal_limit_to_on_off(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_from_on_off(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_to_on_off(pm, i, cnd=c)
         end
 
-        for i in PMs.ids(pm, :dcline)
-            PMs.constraint_dcline(pm, i, cnd=c)
+        for i in _PMs.ids(pm, :dcline)
+            _PMs.constraint_dcline(pm, i, cnd=c)
         end
     end
 
-    PMs.objective_min_fuel_cost(pm)
+    _PMs.objective_min_fuel_cost(pm)
 end

--- a/src/prob/tp_pf.jl
+++ b/src/prob/tp_pf.jl
@@ -3,92 +3,90 @@ export run_ac_tp_pf, run_tp_pf
 
 ""
 function run_ac_tp_pf(file, solver; kwargs...)
-    return run_tp_pf(file, PMs.ACPPowerModel, solver; kwargs...)
+    return run_tp_pf(file, _PMs.ACPPowerModel, solver; kwargs...)
 end
 
 
 ""
 function run_dc_tp_pf(file, solver; kwargs...)
-    return run_tp_pf(file, PMs.DCPPowerModel, solver; kwargs...)
+    return run_tp_pf(file, _PMs.DCPPowerModel, solver; kwargs...)
 end
 
 
 ""
 function run_tp_pf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_pf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
 end
 
 
 ""
-function post_tp_pf(pm::PMs.GenericPowerModel)
+function post_tp_pf(pm::_PMs.GenericPowerModel)
     add_arcs_trans!(pm)
 
     variable_tp_voltage(pm, bounded=false)
     variable_tp_branch_flow(pm, bounded=false)
 
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_generation(pm, bounded=false, cnd=c)
-        PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_generation(pm, bounded=false, cnd=c)
+        _PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
     variable_tp_trans_flow(pm, bounded=false)
 
-    constraint_tp_voltage(pm)
+    constraint_tp_model_voltage(pm)
 
-    for (i,bus) in PMs.ref(pm, :ref_buses)
+    for (i,bus) in _PMs.ref(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
 
-        for c in PMs.conductor_ids(pm)
+        for c in _PMs.conductor_ids(pm)
             @assert bus["bus_type"] == 3
-            PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
         end
     end
 
-    for (i,bus) in PMs.ref(pm, :bus), c in PMs.conductor_ids(pm)
-        constraint_kcl_shunt_trans(pm, i, cnd=c)
+    for (i,bus) in _PMs.ref(pm, :bus), c in _PMs.conductor_ids(pm)
+        constraint_tp_power_balance_shunt_trans(pm, i, cnd=c)
 
         # PV Bus Constraints
-        if length(PMs.ref(pm, :bus_gens, i)) > 0 && !(i in PMs.ids(pm,:ref_buses))
+        if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
             # this assumes inactive generators are filtered out of bus_gens
             @assert bus["bus_type"] == 2
 
-            PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-            for j in PMs.ref(pm, :bus_gens, i)
-                PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
+            for j in _PMs.ref(pm, :bus_gens, i)
+                _PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
             end
         end
     end
 
-    for i in PMs.ids(pm, :branch), c in PMs.conductor_ids(pm)
-        constraint_ohms_tp_yt_from(pm, i, cnd=c)
-        constraint_ohms_tp_yt_to(pm, i, cnd=c)
-        # PMs.constraint_ohms_yt_from(pm, i, cnd=c)
-        # PMs.constraint_ohms_yt_to(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :branch), c in _PMs.conductor_ids(pm)
+        constraint_tp_ohms_yt_from(pm, i, cnd=c)
+        constraint_tp_ohms_yt_to(pm, i, cnd=c)
     end
 
-    for (i,dcline) in PMs.ref(pm, :dcline), c in PMs.conductor_ids(pm)
+    for (i,dcline) in _PMs.ref(pm, :dcline), c in _PMs.conductor_ids(pm)
 
-        PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
+        _PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
 
-        f_bus = PMs.ref(pm, :bus)[dcline["f_bus"]]
+        f_bus = _PMs.ref(pm, :bus)[dcline["f_bus"]]
         if f_bus["bus_type"] == 1
-            PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
         end
 
-        t_bus = PMs.ref(pm, :bus)[dcline["t_bus"]]
+        t_bus = _PMs.ref(pm, :bus)[dcline["t_bus"]]
         if t_bus["bus_type"] == 1
-            PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
         end
     end
 
-    for i in PMs.ids(pm, :trans)
+    for i in _PMs.ids(pm, :trans)
         constraint_tp_trans(pm, i)
     end
 

--- a/src/prob/tp_pf.jl
+++ b/src/prob/tp_pf.jl
@@ -15,14 +15,14 @@ end
 
 ""
 function run_tp_pf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
 end
 
 
 ""
 function run_tp_pf(file::String, model_constructor, solver; kwargs...)
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_pf; multiconductor=true, kwargs...)
 end
 
 

--- a/src/prob/tp_pf_bf.jl
+++ b/src/prob/tp_pf_bf.jl
@@ -5,7 +5,7 @@ function run_tp_pf_bf(data::Dict{String,Any}, model_constructor, solver; kwargs.
     if model_constructor != SDPUBFPowerModel && model_constructor != SOCNLPUBFPowerModel && model_constructor != SOCConicUBFPowerModel && model_constructor != LPUBFPowerModel && model_constructor != LPdiagUBFPowerModel && model_constructor !=  SOCBFPowerModel
         Memento.error(_LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
     end
-    return PMs.run_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
 
 
@@ -15,78 +15,78 @@ function run_tp_pf_bf(file::String, model_constructor, solver; kwargs...)
         Memento.error(_LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
     end
     data = ThreePhasePowerModels.parse_file(file)
-    return PMs.run_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
 
 
 ""
-function post_tp_pf_bf(pm::PMs.GenericPowerModel)
+function post_tp_pf_bf(pm::_PMs.GenericPowerModel)
     # Variables
     variable_tp_voltage(pm, bounded=false)
     variable_tp_branch_current(pm)
     variable_tp_branch_flow(pm)
 
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_generation(pm, bounded=false, cnd=c)
-        PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_generation(pm, bounded=false, cnd=c)
+        _PMs.variable_dcline_flow(pm, bounded=false, cnd=c)
     end
 
     # Constraints
-    constraint_tp_branch_current(pm)
+    constraint_tp_model_current(pm)
 
-    for (i,bus) in PMs.ref(pm, :ref_buses)
+    for (i,bus) in _PMs.ref(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
 
-        for c in PMs.conductor_ids(pm)
+        for c in _PMs.conductor_ids(pm)
             @assert bus["bus_type"] == 3
-            # PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c) #TODO add back
+            # _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c) #TODO add back
         end
     end
 
-    for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        PMs. constraint_power_balance_shunt(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_power_balance_shunt(pm, i, cnd=c)
 
         # PV Bus Constraints
-        if length(PMs.ref(pm, :bus_gens, i)) > 0 && !(i in PMs.ids(pm,:ref_buses))
+        if length(_PMs.ref(pm, :bus_gens, i)) > 0 && !(i in _PMs.ids(pm,:ref_buses))
             # this assumes inactive generators are filtered out of bus_gens
             @assert bus["bus_type"] == 2
 
-            PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
-            for j in PMs.ref(pm, :bus_gens, i)
-                PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
+            _PMs.constraint_voltage_magnitude_setpoint(pm, i, cnd=c)
+            for j in _PMs.ref(pm, :bus_gens, i)
+                _PMs.constraint_active_gen_setpoint(pm, j, cnd=c)
             end
         end
     end
 
-    for i in PMs.ids(pm, :branch)
+    for i in _PMs.ids(pm, :branch)
         constraint_tp_flow_losses(pm, i)
 
-        constraint_tp_voltage_magnitude_difference(pm, i)
+        constraint_tp_model_voltage_magnitude_difference(pm, i)
 
-        for c in PMs.conductor_ids(pm)
+        for c in _PMs.conductor_ids(pm)
             constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
     end
 
-    for (i,dcline) in PMs.ref(pm, :dcline)
-        for c in PMs.conductor_ids(pm)
+    for (i,dcline) in _PMs.ref(pm, :dcline)
+        for c in _PMs.conductor_ids(pm)
 
-            PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
+            _PMs.constraint_active_dcline_setpoint(pm, i, cnd=c)
 
-            f_bus = PMs.ref(pm, :bus)[dcline["f_bus"]]
+            f_bus = _PMs.ref(pm, :bus)[dcline["f_bus"]]
             if f_bus["bus_type"] == 1
-                PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
+                _PMs.constraint_voltage_magnitude_setpoint(pm, f_bus["index"], cnd=c)
             end
 
-            t_bus = PMs.ref(pm, :bus)[dcline["t_bus"]]
+            t_bus = _PMs.ref(pm, :bus)[dcline["t_bus"]]
             if t_bus["bus_type"] == 1
-                PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
+                _PMs.constraint_voltage_magnitude_setpoint(pm, t_bus["index"], cnd=c)
             end
         end
     end
 
-     PMs.objective_min_fuel_cost(pm)
+     _PMs.objective_min_fuel_cost(pm)
 end

--- a/src/prob/tp_pf_bf.jl
+++ b/src/prob/tp_pf_bf.jl
@@ -3,7 +3,7 @@ export run_tp_pf_bf
 ""
 function run_tp_pf_bf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
     if model_constructor != SDPUBFPowerModel && model_constructor != SOCNLPUBFPowerModel && model_constructor != SOCConicUBFPowerModel && model_constructor != LPUBFPowerModel && model_constructor != LPdiagUBFPowerModel && model_constructor !=  SOCBFPowerModel
-        Memento.error(LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
+        Memento.error(_LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
     end
     return PMs.run_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)
 end
@@ -12,7 +12,7 @@ end
 ""
 function run_tp_pf_bf(file::String, model_constructor, solver; kwargs...)
     if model_constructor != SDPUBFPowerModel && model_constructor != SOCNLPUBFPowerModel && model_constructor != SOCConicUBFPowerModel && model_constructor != LPUBFPowerModel && model_constructor !=  SOCBFPowerModel
-        Memento.error(LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
+        Memento.error(_LOGGER, "The problem type tp_opf_bf at the moment only supports a limited set of formulations")
     end
     data = ThreePhasePowerModels.parse_file(file)
     return PMs.run_model(data, model_constructor, solver, post_tp_pf_bf; solution_builder=get_solution_tp, multiconductor=true, kwargs...)

--- a/src/prob/tp_test.jl
+++ b/src/prob/tp_test.jl
@@ -7,7 +7,7 @@
 
 "opf with storage"
 function run_tp_strg_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_tp_strg_opf; multiconductor=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_tp_strg_opf; multiconductor=true, kwargs...)
 end
 
 ""
@@ -28,7 +28,7 @@ function post_tp_strg_opf(pm::PMs.GenericPowerModel)
     end
 
     for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        PMs.constraint_kcl_shunt_storage(pm, i, cnd=c)
+        PMs.constraint_power_balance_shunt_storage(pm, i, cnd=c)
     end
 
     for i in PMs.ids(pm, :storage)
@@ -63,7 +63,7 @@ end
 
 "multi-network opf with storage"
 function run_mn_tp_strg_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_generic_model(data, model_constructor, solver, post_mn_tp_strg_opf; multiconductor=true, multinetwork=true, kwargs...)
+    return PMs.run_model(data, model_constructor, solver, post_mn_tp_strg_opf; multiconductor=true, multinetwork=true, kwargs...)
 end
 
 ""
@@ -85,7 +85,7 @@ function post_mn_tp_strg_opf(pm::PMs.GenericPowerModel)
         end
 
         for i in PMs.ids(pm, :bus, nw=n), c in PMs.conductor_ids(pm, nw=n)
-            PMs.constraint_kcl_shunt_storage(pm, i, cnd=c, nw=n)
+            PMs.constraint_power_balance_shunt_storage(pm, i, cnd=c, nw=n)
         end
 
         for i in PMs.ids(pm, :storage, nw=n)

--- a/src/prob/tp_test.jl
+++ b/src/prob/tp_test.jl
@@ -7,55 +7,55 @@
 
 "opf with storage"
 function run_tp_strg_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_tp_strg_opf; multiconductor=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_tp_strg_opf; multiconductor=true, kwargs...)
 end
 
 ""
-function post_tp_strg_opf(pm::PMs.GenericPowerModel)
+function post_tp_strg_opf(pm::_PMs.GenericPowerModel)
     variable_tp_voltage(pm)
     variable_tp_branch_flow(pm)
     variable_tp_storage(pm)
 
-    for c in PMs.conductor_ids(pm)
-        PMs.variable_generation(pm, cnd=c)
-        PMs.variable_dcline_flow(pm, cnd=c)
+    for c in _PMs.conductor_ids(pm)
+        _PMs.variable_generation(pm, cnd=c)
+        _PMs.variable_dcline_flow(pm, cnd=c)
     end
 
-    constraint_tp_voltage(pm)
+    constraint_tp_model_voltage(pm)
 
-    for i in PMs.ids(pm, :ref_buses)
+    for i in _PMs.ids(pm, :ref_buses)
         constraint_tp_theta_ref(pm, i)
     end
 
-    for i in PMs.ids(pm, :bus), c in PMs.conductor_ids(pm)
-        PMs.constraint_power_balance_shunt_storage(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :bus), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_power_balance_shunt_storage(pm, i, cnd=c)
     end
 
-    for i in PMs.ids(pm, :storage)
-        PMs.constraint_storage_state(pm, i)
+    for i in _PMs.ids(pm, :storage)
+        _PMs.constraint_storage_state(pm, i)
         constraint_tp_storage_exchange(pm, i)
-        for c in PMs.conductor_ids(pm)
-            PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
+        for c in _PMs.conductor_ids(pm)
+            _PMs.constraint_storage_thermal_limit(pm, i, cnd=c)
         end
     end
 
-    for i in PMs.ids(pm, :branch)
-        for c in PMs.conductor_ids(pm)
-            constraint_ohms_tp_yt_from(pm, i, cnd=c)
-            constraint_ohms_tp_yt_to(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :branch)
+        for c in _PMs.conductor_ids(pm)
+            constraint_tp_ohms_yt_from(pm, i, cnd=c)
+            constraint_tp_ohms_yt_to(pm, i, cnd=c)
 
-            PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
+            _PMs.constraint_voltage_angle_difference(pm, i, cnd=c)
 
-            PMs.constraint_thermal_limit_from(pm, i, cnd=c)
-            PMs.constraint_thermal_limit_to(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_from(pm, i, cnd=c)
+            _PMs.constraint_thermal_limit_to(pm, i, cnd=c)
         end
     end
 
-    for i in PMs.ids(pm, :dcline), c in PMs.conductor_ids(pm)
-        PMs.constraint_dcline(pm, i, cnd=c)
+    for i in _PMs.ids(pm, :dcline), c in _PMs.conductor_ids(pm)
+        _PMs.constraint_dcline(pm, i, cnd=c)
     end
 
-    PMs.objective_min_fuel_cost(pm)
+    _PMs.objective_min_fuel_cost(pm)
 end
 
 
@@ -63,68 +63,68 @@ end
 
 "multi-network opf with storage"
 function run_mn_tp_strg_opf(data::Dict{String,Any}, model_constructor, solver; kwargs...)
-    return PMs.run_model(data, model_constructor, solver, post_mn_tp_strg_opf; multiconductor=true, multinetwork=true, kwargs...)
+    return _PMs.run_model(data, model_constructor, solver, post_mn_tp_strg_opf; multiconductor=true, multinetwork=true, kwargs...)
 end
 
 ""
-function post_mn_tp_strg_opf(pm::PMs.GenericPowerModel)
-    for (n, network) in PMs.nws(pm)
+function post_mn_tp_strg_opf(pm::_PMs.GenericPowerModel)
+    for (n, network) in _PMs.nws(pm)
         variable_tp_voltage(pm, nw=n)
         variable_tp_branch_flow(pm, nw=n)
         variable_tp_storage(pm, nw=n)
 
-        for c in PMs.conductor_ids(pm, nw=n)
-            PMs.variable_generation(pm, cnd=c, nw=n)
-            PMs.variable_dcline_flow(pm, cnd=c, nw=n)
+        for c in _PMs.conductor_ids(pm, nw=n)
+            _PMs.variable_generation(pm, cnd=c, nw=n)
+            _PMs.variable_dcline_flow(pm, cnd=c, nw=n)
         end
 
-        constraint_tp_voltage(pm, nw=n)
+        constraint_tp_model_voltage(pm, nw=n)
 
-        for i in PMs.ids(pm, :ref_buses, nw=n)
+        for i in _PMs.ids(pm, :ref_buses, nw=n)
             constraint_tp_theta_ref(pm, i, nw=n)
         end
 
-        for i in PMs.ids(pm, :bus, nw=n), c in PMs.conductor_ids(pm, nw=n)
-            PMs.constraint_power_balance_shunt_storage(pm, i, cnd=c, nw=n)
+        for i in _PMs.ids(pm, :bus, nw=n), c in _PMs.conductor_ids(pm, nw=n)
+            _PMs.constraint_power_balance_shunt_storage(pm, i, cnd=c, nw=n)
         end
 
-        for i in PMs.ids(pm, :storage, nw=n)
+        for i in _PMs.ids(pm, :storage, nw=n)
             constraint_tp_storage_exchange(pm, i, nw=n)
-            for c in PMs.conductor_ids(pm, nw=n)
-                PMs.constraint_storage_thermal_limit(pm, i, cnd=c, nw=n)
+            for c in _PMs.conductor_ids(pm, nw=n)
+                _PMs.constraint_storage_thermal_limit(pm, i, cnd=c, nw=n)
             end
         end
 
-        for i in PMs.ids(pm, :branch, nw=n)
-            for c in PMs.conductor_ids(pm, nw=n)
-                constraint_ohms_tp_yt_from(pm, i, cnd=c, nw=n)
-                constraint_ohms_tp_yt_to(pm, i, cnd=c, nw=n)
+        for i in _PMs.ids(pm, :branch, nw=n)
+            for c in _PMs.conductor_ids(pm, nw=n)
+                constraint_tp_ohms_yt_from(pm, i, cnd=c, nw=n)
+                constraint_tp_ohms_yt_to(pm, i, cnd=c, nw=n)
 
-                PMs.constraint_voltage_angle_difference(pm, i, cnd=c, nw=n)
+                _PMs.constraint_voltage_angle_difference(pm, i, cnd=c, nw=n)
 
-                PMs.constraint_thermal_limit_from(pm, i, cnd=c, nw=n)
-                PMs.constraint_thermal_limit_to(pm, i, cnd=c, nw=n)
+                _PMs.constraint_thermal_limit_from(pm, i, cnd=c, nw=n)
+                _PMs.constraint_thermal_limit_to(pm, i, cnd=c, nw=n)
             end
         end
 
-        for i in PMs.ids(pm, :dcline, nw=n), c in PMs.conductor_ids(pm, nw=n)
-            PMs.constraint_dcline(pm, i, cnd=c, nw=n)
+        for i in _PMs.ids(pm, :dcline, nw=n), c in _PMs.conductor_ids(pm, nw=n)
+            _PMs.constraint_dcline(pm, i, cnd=c, nw=n)
         end
     end
 
-    network_ids = sort(collect(PMs.nw_ids(pm)))
+    network_ids = sort(collect(_PMs.nw_ids(pm)))
 
     n_1 = network_ids[1]
-    for i in PMs.ids(pm, :storage, nw=n_1)
-        PMs.constraint_storage_state(pm, i, nw=n_1)
+    for i in _PMs.ids(pm, :storage, nw=n_1)
+        _PMs.constraint_storage_state(pm, i, nw=n_1)
     end
 
     for n_2 in network_ids[2:end]
-        for i in PMs.ids(pm, :storage, nw=n_2)
-            PMs.constraint_storage_state(pm, i, n_1, n_2)
+        for i in _PMs.ids(pm, :storage, nw=n_2)
+            _PMs.constraint_storage_state(pm, i, n_1, n_2)
         end
         n_1 = n_2
     end
 
-    PMs.objective_min_fuel_cost(pm)
+    _PMs.objective_min_fuel_cost(pm)
 end

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -32,8 +32,8 @@ vm(sol, tppm_data, name) = sol["solution"]["bus"][string(bus_name2id(tppm_data, 
             # free the taps
             tppm_data["trans"]["1"]["fixed"] = PMs.MultiConductorVector(zeros(Bool, 3))
             tppm_data["trans"]["2"]["fixed"] = PMs.MultiConductorVector(zeros(Bool, 3))
-            pm = PMs.build_generic_model(tppm_data, PMs.ACPPowerModel, TPPMs.post_tp_opf_oltc, multiconductor=true)
-            sol = PMs.solve_generic_model(pm, ipopt_solver)
+            pm = PMs.build_model(tppm_data, PMs.ACPPowerModel, TPPMs.post_tp_opf_oltc, multiconductor=true)
+            sol = PMs.optimize_model!(pm, ipopt_solver)
             # check that taps are set as to boost the voltage in the branches as much as possible;
             # this is trivially optimal if the voltage bounds are not binding
             # and without significant shunts (both branch and transformer)


### PR DESCRIPTION
Updated constraint names to be more consistent with PowerModels, and updated PMs function calls to new function names:

- const `PMs` -> `_PMs`
- global `LOGGER` -> `_LOGGER`
- `constraint_tp_voltage` -> `constraint_tp_model_voltage`
- `constraint_kcl_...` -> `constraint_power_balance_...`
- `constraint_tp_branch_current` -> `constraint_tp_model_current`
- `constraint_ohms_tp_yt_...` -> `constraint_tp_ohms_yt_...`
- `constraint_voltage_magnitude_difference` -> `constraint_tp_voltage_magnitude_difference`
- `constraint_flow_losses` -> `constraint_tp_flow_losses`
- `add_...` -> `add_...!`
- `cm` -> `ccm`

Adds automatic exporting of all non-internal function in TPPMs (those not starting with `_`)

Currently uses PowerModels#master in `Manifest.toml` due to bug fix in `add_setpoint!`